### PR TITLE
Add support for maven alongside existing build system

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="con" path="at.bestsolution.efxclipse.tooling.jdt.core.JAVAFX_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="con" path="org.eclipse.fx.ide.jdt.core.JAVAFX_CONTAINER"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.jar
 *.bat
 
+/target/

--- a/.project
+++ b/.project
@@ -15,8 +15,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -9,4 +9,5 @@ org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.7

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+script:
+ - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+ - mvn jfx:jar

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 	      <artifactId>javafx-maven-plugin</artifactId>
 	      <version>8.6.0</version>
 	      <configuration>
-		      <mainClass>smp.SuperMarioPaint</mainClass>
-          <preLoader>smp.fx.SplashScreen</preLoader>
+		<mainClass>smp.SuperMarioPaint</mainClass>
+          	<preLoader>smp.fx.SplashScreen</preLoader>
 	      </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,15 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+	      <groupId>com.zenjava</groupId>
+	      <artifactId>javafx-maven-plugin</artifactId>
+	      <version>8.6.0</version>
+	      <configuration>
+		      <mainClass>smp.SuperMarioPaint</mainClass>
+          <preLoader>smp.fx.SplashScreen</preLoader>
+	      </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 	      <artifactId>javafx-maven-plugin</artifactId>
 	      <version>8.6.0</version>
 	      <configuration>
-		<mainClass>smp.SuperMarioPaint</mainClass>
-          	<preLoader>smp.fx.SplashScreen</preLoader>
+		      <mainClass>smp.SuperMarioPaint</mainClass>
+          <preLoader>smp.fx.SplashScreen</preLoader>
 	      </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>DC37</groupId>
+  <artifactId>Super-Mario-Paint</artifactId>
+  <version>1.1.1</version>
+  <name>Super Mario Paint</name>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This pull request does the following:
* Add maven support to this project while leaving the current build system in place
* Makes usage of CI like Travis CI possible
  * This makes it easy to test if a commit broke the current build or if something that made the build compilable was left out. This also automatically checks whether a pull request builds as well. I've worked on this for 1-2 hours to ensure this works completely with the project and operates as fast as possible. 
  * [![Build Status](https://travis-ci.org/rogersachan/Super-Mario-Paint.svg?branch=master)](https://travis-ci.org/rogersachan/Super-Mario-Paint) Click on this build button to see it in action.