### PR TITLE
Undo/redo for Multiply tempo + Various bugfixes

### DIFF
--- a/src/smp/SuperMarioPaint.java
+++ b/src/smp/SuperMarioPaint.java
@@ -37,6 +37,7 @@ import javafx.stage.WindowEvent;
 import smp.components.Values;
 import smp.components.InstrumentIndex;
 import smp.components.staff.StaffInstrumentEventHandler;
+import smp.fx.Dialog;
 import smp.fx.SMPFXController;
 import smp.fx.SplashScreen;
 import smp.stateMachine.ProgramState;
@@ -249,58 +250,25 @@ public class SuperMarioPaint extends Application {
      * release.
      */
     private void handleCloseRequest() {
-        if (!StateMachine.isSongModified()
-                && !StateMachine.isArrModified()) {
+        String mssg;
+        
+        if (StateMachine.isSongModified()
+                && StateMachine.isArrModified()) {
+            mssg = "The song and arrangement have\n"
+                    + "both not been saved! Really exit?";
+        } else if (StateMachine.isSongModified()) {
+            mssg = "The song has not been saved! "
+                    + "Really exit?";
+        } else if (StateMachine.isArrModified()) {
+            mssg = "The arrangement has not been saved! "
+                    + "Really exit?";
+        } else {
             stop();
             return;
         }
     
-        final Stage dialog = new Stage();
-        dialog.setHeight(100);
-        dialog.setWidth(300);
-        dialog.setResizable(false);
-        dialog.initStyle(StageStyle.UTILITY);
-        Label label = new Label();
-        label.setMaxWidth(300);
-        label.setWrapText(true);
-        if (StateMachine.isSongModified()
-                && StateMachine.isArrModified()) {
-            label.setText("The song and arrangement have\n"
-                    + "both not been saved! Really exit?");
-        } else if (StateMachine.isSongModified()) {
-            label.setText("The song has not been saved! "
-                    + "Really exit?");
-        } else if (StateMachine.isArrModified()) {
-            label.setText("The arrangement has not been saved! "
-                    + "Really exit?");
-        }
-        Button okButton = new Button("Yes");
-        okButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                dialog.close();
-                stop();
-
-            }
-        });
-        Button cancelButton = new Button("No");
-        cancelButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                dialog.close();
-            }
-        });
-        FlowPane pane = new FlowPane(10, 10);
-        pane.setAlignment(Pos.CENTER);
-        pane.getChildren().addAll(okButton, cancelButton);
-        VBox vBox = new VBox(10);
-        vBox.setAlignment(Pos.CENTER);
-        vBox.getChildren().addAll(label, pane);
-        Scene scene1 = new Scene(vBox);
-        dialog.setScene(scene1);
-        dialog.show();
+        if (Dialog.showYesNoDialog(mssg))
+            stop();
     }
     
     private void makeMouseEventHandlers() {

--- a/src/smp/commandmanager/commands/MultiplyTempoCommand.java
+++ b/src/smp/commandmanager/commands/MultiplyTempoCommand.java
@@ -6,15 +6,20 @@ import smp.commandmanager.CommandInterface;
 import smp.components.Values;
 import smp.components.staff.Staff;
 import smp.components.staff.sequences.StaffNoteLine;
+import smp.stateMachine.StateMachine;
 
 public class MultiplyTempoCommand implements CommandInterface {
 
 	Staff theStaff;
 	int theMultiplyAmount;
+	double previousTempo;
+	double newTempo;
 	
-	public MultiplyTempoCommand(Staff staff, int multiplyAmount) {
+	public MultiplyTempoCommand(Staff staff, int num, double previousTempo, double newTempo) {
 		theStaff = staff;
-		theMultiplyAmount = multiplyAmount;
+		this.theMultiplyAmount = num;
+		this.previousTempo = previousTempo;
+		this.newTempo = newTempo;
 	}
 	
 	@Override
@@ -28,8 +33,7 @@ public class MultiplyTempoCommand implements CommandInterface {
         }
         s.clear();
         s.addAll(n);
-//        StateMachine.setTempo(theStaff.getSequence().getTempo() * num);
-//        theStaff.updateCurrTempo();
+        StateMachine.setTempo(newTempo);
         theStaff.getControlPanel().getScrollbar()
                 .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
 	}
@@ -43,8 +47,7 @@ public class MultiplyTempoCommand implements CommandInterface {
 		}
         s.clear();
         s.addAll(n);
-//      StateMachine.setTempo(theStaff.getSequence().getTempo() * num);
-//      theStaff.updateCurrTempo();
+        StateMachine.setTempo(previousTempo);
 	    theStaff.getControlPanel().getScrollbar()
 	            .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
 	}

--- a/src/smp/components/buttons/OptionsButton.java
+++ b/src/smp/components/buttons/OptionsButton.java
@@ -315,10 +315,9 @@ public class OptionsButton extends ImagePushButton {
             }
             s.clear();
             s.addAll(n);
-            double currTempo = Double.parseDouble(theStaff.getControlPanel().getCurrTempo().get());
+            double currTempo = StateMachine.getTempo();
             double newTempo = currTempo * num;
             StateMachine.setTempo(newTempo);
-            theStaff.updateCurrTempo();
             theStaff.getControlPanel().getScrollbar()
                     .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
             

--- a/src/smp/components/buttons/OptionsButton.java
+++ b/src/smp/components/buttons/OptionsButton.java
@@ -321,7 +321,7 @@ public class OptionsButton extends ImagePushButton {
             theStaff.getControlPanel().getScrollbar()
                     .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
             
-            controller.getModifySongManager().execute(new MultiplyTempoCommand(theStaff, num));
+            controller.getModifySongManager().execute(new MultiplyTempoCommand(theStaff, num, currTempo, newTempo));
             controller.getModifySongManager().record();
         }
     }

--- a/src/smp/components/buttons/SaveButton.java
+++ b/src/smp/components/buttons/SaveButton.java
@@ -107,7 +107,7 @@ public class SaveButton extends ImagePushButton {
     private void saveArrangement() {
         String songName = controller.getNameTextField().getText();
         if (!Utilities.legalFileName(songName)) {
-            Dialog.showDialog("Illegal file name!");
+            Dialog.showDialog("Illegal file name!\nPlease avoid those characters:\n/, \\, <, >, :, |, *, \", ?, ^");
             return;
         }
         
@@ -183,7 +183,7 @@ public class SaveButton extends ImagePushButton {
     private void saveSong() {
         String songName = controller.getNameTextField().getText();
         if (!Utilities.legalFileName(songName)) {
-            Dialog.showDialog("Illegal file name!");
+            Dialog.showDialog("Illegal file name!\nPlease avoid those characters:\n /, \\, <, >, :, |, *, \", ?, ^");
             return;
         }
         

--- a/src/smp/components/buttons/SaveButton.java
+++ b/src/smp/components/buttons/SaveButton.java
@@ -23,6 +23,7 @@ import smp.components.staff.sequences.StaffArrangement;
 import smp.components.staff.sequences.StaffNote;
 import smp.components.staff.sequences.StaffNoteLine;
 import smp.components.staff.sequences.StaffSequence;
+import smp.fx.Dialog;
 import smp.fx.SMPFXController;
 import smp.stateMachine.ProgramState;
 import smp.stateMachine.Settings;
@@ -104,11 +105,16 @@ public class SaveButton extends ImagePushButton {
 
     /** Saves the arrangement. */
     private void saveArrangement() {
+        String songName = controller.getNameTextField().getText();
+        if (!Utilities.legalFileName(songName)) {
+            Dialog.showDialog("Illegal file name!");
+            return;
+        }
+        
         try {
             FileChooser f = new FileChooser();
             f.setInitialDirectory(StateMachine.getCurrentDirectory());
-            f.setInitialFileName(controller.getNameTextField().getText()
-                    + ".txt");
+            f.setInitialFileName(songName + ".txt");
             f.getExtensionFilters().addAll(
                     new ExtensionFilter("Text file", "*.txt"),
                     new ExtensionFilter("All files", "*"));
@@ -175,11 +181,16 @@ public class SaveButton extends ImagePushButton {
      * Saves the current song to disk.
      */
     private void saveSong() {
+        String songName = controller.getNameTextField().getText();
+        if (!Utilities.legalFileName(songName)) {
+            Dialog.showDialog("Illegal file name!");
+            return;
+        }
+        
         try {
             FileChooser f = new FileChooser();
             f.setInitialDirectory(StateMachine.getCurrentDirectory());
-            f.setInitialFileName(controller.getNameTextField().getText()
-                    + ".txt");
+            f.setInitialFileName(songName + ".txt");
             f.getExtensionFilters().addAll(
                     new ExtensionFilter("Text file", "*.txt"),
                     new ExtensionFilter("All files", "*"));

--- a/src/smp/components/buttons/TempoAdjustButton.java
+++ b/src/smp/components/buttons/TempoAdjustButton.java
@@ -23,9 +23,6 @@ import smp.stateMachine.StateMachine;
  */
 public class TempoAdjustButton extends ImagePushButton {
 
-    /** This is the current tempo. */
-    private StringProperty currTempo;
-
     /** Tells us whether this is a plus or minus button. */
     private boolean isPositive;
 
@@ -64,16 +61,6 @@ public class TempoAdjustButton extends ImagePushButton {
         return isPositive;
     }
 
-    /**
-     * Sets the String property to display the tempo.
-     *
-     * @param s
-     *            This is the StringProperty that displays the tempo.
-     */
-    public void setStringProperty(StringProperty s) {
-        currTempo = s;
-    }
-
     @Override
     protected void reactPressed(MouseEvent event) {
         ProgramState curr = StateMachine.getState();
@@ -109,7 +96,6 @@ public class TempoAdjustButton extends ImagePushButton {
                     ch = -add;
                 double tempo = StateMachine.getTempo() + ch;
                 StateMachine.setTempo(tempo);
-                currTempo.setValue(String.valueOf(tempo));
             }
         });
     }

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -96,9 +96,6 @@ public class Controls {
 	/** This is the staff that the controls are linked to. */
 	private Staff theStaff;
 
-	/** This is the current tempo. */
-	private StringProperty currTempo = new SimpleStringProperty();
-
 	/** The ListView of songs for the arranger. */
 	private ListView<String> theList;
 
@@ -123,7 +120,6 @@ public class Controls {
 		initializeControlButtons();
 		theStaff.setCurrVal(scrollbar.valueProperty());
 		initializeTempoButtons();
-		currTempo.setValue(String.valueOf(StateMachine.getTempo()));
 		initializeLoadSaveButtons();
 		initializeNewButton();
 		initializeArrangementList();
@@ -173,10 +169,6 @@ public class Controls {
 		TempoAdjustButton minus = new TempoAdjustButton(controller.getTempoMinus(), controller, il);
 		plus.setPositive(true);
 		minus.setPositive(false);
-		StringProperty tempoDisplay = controller.getTempoIndicator().textProperty();
-		currTempo.bindBidirectional(tempoDisplay);
-		plus.setStringProperty(currTempo);
-		minus.setStringProperty(currTempo);
 		StackPane tBox = controller.getTempoBox();
 
 		tBox.setOnMousePressed(new EventHandler<MouseEvent>() {
@@ -188,7 +180,6 @@ public class Controls {
 						String tempo = Dialog.showTextDialog("Tempo");
 						StateMachine.setTempo(Double.parseDouble(tempo));
 						tempo = tempo.trim();
-						currTempo.setValue(tempo);
 					}
 				} catch (NumberFormatException e) {
 					// Do nothing.
@@ -385,13 +376,6 @@ public class Controls {
 	 */
 	public Slider getScrollbar() {
 		return scrollbar;
-	}
-
-	/**
-	 * @return The current tempo object that we want to modify.
-	 */
-	public StringProperty getCurrTempo() {
-		return currTempo;
 	}
 
 	/**

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -435,7 +435,6 @@ public class Utilities {
         theStaff.setSequence(loaded);
         theStaff.setSequenceFile(inputFile);
         StateMachine.setTempo(loaded.getTempo());
-        theStaff.updateCurrTempo();
         theStaff.getControlPanel()
                 .getScrollbar()
                 .setMax(loaded.getTheLines().size()

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -490,7 +490,7 @@ public class Utilities {
             }
         }
         for (int i = 0; i < loaded.getTheSequenceFiles().size(); i++) {
-            String fName = cleanName(loaded.getTheSequenceNames().get(i));
+            String fName = loaded.getTheSequenceNames().get(i);
             String newPath = basePath + fName + ".txt";
             File f2 = new File(newPath);
             if (!f2.exists()) {
@@ -511,6 +511,8 @@ public class Utilities {
      * slashes replaced with underscores.
      */
     public static String cleanName(String f) {
+        // unused---seems to only be causing problems
+        // TODO consider normalizing all file names for saving and loading
 
         f = f.replaceAll("'", "_");
         f = f.replaceAll("\\\\", "_");

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -522,6 +522,34 @@ public class Utilities {
         
         return f;
     }
+    
+    /**
+     * Check if a string does not contain any illegal character.
+     */
+    public static boolean legalFileName(String s) {
+        for (char c : s.toCharArray()) {
+            if (!legalCharacter(c))
+                return false;
+        }
+        return true;
+    }
+    
+    private static boolean legalCharacter(char c) {
+        switch (c) {
+        case '<':
+        case '>':
+        case '/':
+        case '\\':
+        case ':':
+        case '?':
+        case '|':
+        case '*':
+        case '"':
+        case '^':
+            return false;
+        }
+        return true;
+    }
 
 	/**
 	 * Populates the staff with the arrangement given. Loads each soundfont

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -267,17 +267,6 @@ public class Staff {
         animationService.restart();
     }
 
-    /** Updates the current tempo - staff version. */
-    public synchronized void updateCurrTempo() {
-        Platform.runLater(new Runnable() {
-            @Override
-            public void run() {
-                theControls.getCurrTempo().setValue(
-                        String.valueOf(StateMachine.getTempo()));
-            }
-        });
-    }
-
     /**
      * Finds the last line in the sequence that we are playing.
      */
@@ -815,8 +804,6 @@ public class Staff {
                     controller.getInstBLine().updateNoteExtensions();
                     StateMachine.setTempo(theSequence.getTempo());
                     queue++;
-                    updateCurrTempo();
-                    queue++;
                     setScrollbar();
                     lastLine = findLastLine();
                     songPlaying = true;
@@ -903,18 +890,6 @@ public class Staff {
                         theControls.getScrollbar().setMax(
                                 theSequence.getTheLines().size()
                                         - Values.NOTELINES_IN_THE_WINDOW);
-                        queue--;
-                    }
-                });
-            }
-
-            /** Updates the current tempo - arranger version. */
-            private void updateCurrTempo() {
-                Platform.runLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        theControls.getCurrTempo().setValue(
-                                String.valueOf(StateMachine.getTempo()));
                         queue--;
                     }
                 });

--- a/src/smp/components/staff/StaffInstrumentEventHandler.java
+++ b/src/smp/components/staff/StaffInstrumentEventHandler.java
@@ -539,8 +539,7 @@ public class StaffInstrumentEventHandler implements EventHandler<Event> {
      * @return line in the current window based on x coord
      */
     private static int getLine(double x){
-
-    	if(x < 135 || x > 999)
+    	if(x < 165 || x >= 997)
     		return -1;
     	return (((int)x - 165) / 64);
     }

--- a/src/smp/components/staff/sequences/mpc/MPCDecoder.java
+++ b/src/smp/components/staff/sequences/mpc/MPCDecoder.java
@@ -184,7 +184,7 @@ public class MPCDecoder {
         StaffArrangement theArr = new StaffArrangement();
 
         for (String s : str.split("\n")) {
-        	String sp = Utilities.cleanName(s);
+        	String sp = s;
             String st = inputFile.getParent() + File.separatorChar + sp + "]MarioPaint.txt";
             File f = new File(st);
             StaffSequence seq = decode(f);

--- a/src/smp/fx/Dialog.java
+++ b/src/smp/fx/Dialog.java
@@ -92,8 +92,8 @@ public class Dialog {
         
         Label label = new Label(txt);
         label.setTextAlignment(TextAlignment.CENTER);
-        Button okButton = new Button("OK");
-        Button cancelButton = new Button("Cancel");
+        Button okButton = new Button("Yes");
+        Button cancelButton = new Button("No");
 
         okButton.setOnAction(event -> {
             dialog.close();

--- a/src/smp/fx/Dialog.java
+++ b/src/smp/fx/Dialog.java
@@ -1,16 +1,18 @@
 package smp.fx;
 
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.TextAlignment;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
@@ -27,47 +29,55 @@ public class Dialog {
 
     /** Some text that we type into a field in a text dialog. */
     private static String info = "";
+    
+    private static Stage initDialogStage() {
+        Stage stage = new Stage();
+        stage.setResizable(false);
+        stage.initStyle(StageStyle.UTILITY);
+        return stage;
+    }
+    
+    private static Parent makeLayout(Node... elements) {
+        VBox layout = new VBox();
+        layout.setSpacing(10);
+        layout.setPadding(new Insets(10, 10, 10, 10));
+        layout.setAlignment(Pos.CENTER);
+        layout.getChildren().addAll(elements);
+        return layout;
+    }
+    
+    private static Parent makeRow(Node... elements) {
+        HBox layout = new HBox();
+        layout.setSpacing(10);
+        layout.setAlignment(Pos.CENTER);
+        layout.getChildren().addAll(elements);
+        return layout;
+    }
 
     /**
      * Shows a dialog box with the text given to this method.
      * @param txt The text to show.
      */
     public static void showDialog(String txt) {
-        final Stage dialog = new Stage();
-        dialog.setHeight(150);
-        dialog.setWidth(250);
-        dialog.setResizable(false);
-        dialog.initStyle(StageStyle.UTILITY);
+        final Stage dialog = initDialogStage();
+        
         Label label = new Label(txt);
+        label.setTextAlignment(TextAlignment.CENTER);
         Button okButton = new Button("OK");
 
-        okButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                dialog.close();
-            }
-
-        });
+        okButton.setOnAction(event -> dialog.close());
         
         /* @since 1.4.1, ESC/Enter to close dialog */
-        dialog.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
-            @Override
-            public void handle(KeyEvent ke) {
-            	if (ke.getCode() == KeyCode.ENTER || ke.getCode() == KeyCode.ESCAPE) {
-                    dialog.close();
-            	}
-            }
+        dialog.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER || event.getCode() == KeyCode.ESCAPE)
+                dialog.close();
         });
-
-        FlowPane pane = new FlowPane(10, 10);
-        pane.setAlignment(Pos.CENTER);
-        pane.getChildren().addAll(okButton);
-        VBox vBox = new VBox(10);
-        vBox.setAlignment(Pos.CENTER);
-        vBox.getChildren().addAll(label, pane);
-        Scene scene1 = new Scene(vBox);
-        dialog.setScene(scene1);
+        
+        Parent buttons = makeRow(okButton);
+        Parent layout = makeLayout(label, buttons);
+        
+        Scene scene = new Scene(layout);
+        dialog.setScene(scene);
         dialog.showAndWait();
 
     }
@@ -78,71 +88,47 @@ public class Dialog {
      * @param txt The text to show.
      */
     public static boolean showYesNoDialog(String txt) {
-        final Stage dialog = new Stage();
-        dialog.setHeight(150);
-        dialog.setWidth(250);
-        dialog.setResizable(false);
-        dialog.initStyle(StageStyle.UTILITY);
+        final Stage dialog = initDialogStage();
+        
         Label label = new Label(txt);
+        label.setTextAlignment(TextAlignment.CENTER);
         Button okButton = new Button("OK");
+        Button cancelButton = new Button("Cancel");
 
-        okButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                dialog.close();
-                choice = true;
-                event.consume();
-            }
-
+        okButton.setOnAction(event -> {
+            dialog.close();
+            choice = true;
         });
 
-        Button cancelButton = new Button("Cancel");
-        cancelButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                dialog.close();
-                choice = false;
-                event.consume();
-            }
+        cancelButton.setOnAction(event -> {
+            dialog.close();
+            choice = false;
         });
         
         /* @since 1.4.1, ESC to close dialog, Enter to accept */
-        dialog.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
-            @Override
-            public void handle(KeyEvent ke) {
-            	if (ke.getCode() == KeyCode.ESCAPE) {
-                    choice = false;
-                    dialog.close();
-                    ke.consume();
-            	} else if (ke.getCode() == KeyCode.ENTER) {
-                    choice = true;
-                    dialog.close();
-                    ke.consume();
-            	}
-            }
+        dialog.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+        	if (event.getCode() == KeyCode.ESCAPE) {
+                choice = false;
+                dialog.close();
+        	} else if (event.getCode() == KeyCode.ENTER) {
+                choice = true;
+                dialog.close();
+        	}
         });
 
-        dialog.addEventHandler(WindowEvent.ANY, new EventHandler<WindowEvent>()  {
-            @Override
-            public void handle(WindowEvent we) {
-                if (we.getEventType() == WindowEvent.WINDOW_CLOSE_REQUEST
-                        || we.getEventType() == WindowEvent.WINDOW_HIDDEN
-                        || we.getEventType() == WindowEvent.WINDOW_HIDING)
-                    dialog.close();
-                    return;
-            }
+        dialog.addEventHandler(WindowEvent.ANY, event -> {
+            if (event.getEventType() == WindowEvent.WINDOW_CLOSE_REQUEST
+                    || event.getEventType() == WindowEvent.WINDOW_HIDDEN
+                    || event.getEventType() == WindowEvent.WINDOW_HIDING)
+                dialog.close();
+                return;
         });
         
-        FlowPane pane = new FlowPane(10, 10);
-        pane.setAlignment(Pos.CENTER);
-        pane.getChildren().addAll(okButton, cancelButton);
-        VBox vBox = new VBox(10);
-        vBox.setAlignment(Pos.CENTER);
-        vBox.getChildren().addAll(label, pane);
-        Scene scene1 = new Scene(vBox);
-        dialog.setScene(scene1);
+        Parent buttons = makeRow(okButton, cancelButton);
+        Parent layout = makeLayout(label, buttons);
+        
+        Scene scene = new Scene(layout);
+        dialog.setScene(scene);
         dialog.showAndWait();
         return choice;
     }
@@ -153,60 +139,41 @@ public class Dialog {
      * @param txt The text to show.
      */
     public static String showTextDialog(String txt) {
-        final Stage dialog = new Stage();
-        dialog.setHeight(125);
-        dialog.setWidth(150);
-        dialog.setResizable(false);
-        dialog.initStyle(StageStyle.UTILITY);
+        final Stage dialog = initDialogStage();
+        
         Label label = new Label(txt);
-        final TextField t = new TextField();
+        label.setTextAlignment(TextAlignment.CENTER);
+        final TextField textfield = new TextField();
+        textfield.setPrefColumnCount(8); // rather small; this is only for tempo afaik
         Button okButton = new Button("OK");
+        Button cancelButton = new Button("Cancel");
 
-        okButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                info = t.getText();
-                dialog.close();
-            }
-
+        okButton.setOnAction(event -> {
+            info = textfield.getText();
+            dialog.close();
         });
 
-        Button cancelButton = new Button("Cancel");
-        cancelButton.setOnAction(new EventHandler<ActionEvent>() {
-
-            @Override
-            public void handle(ActionEvent event) {
-                info = "";
-                dialog.close();
-                event.consume();
-            }
+        cancelButton.setOnAction(event -> {
+            info = "";
+            dialog.close();
         });
         
         /* @since 1.4.1, ESC to close dialog, Enter to accept */
-        dialog.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
-            @Override
-            public void handle(KeyEvent ke) {
-            	if (ke.getCode() == KeyCode.ESCAPE) {
-                    info = "";
-                    dialog.close();
-                    ke.consume();
-            	} else if (ke.getCode() == KeyCode.ENTER) {
-                    info = t.getText();
-                    dialog.close();
-                    ke.consume();
-            	}
-            }
+        dialog.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+        	if (event.getCode() == KeyCode.ESCAPE) {
+                info = "";
+                dialog.close();
+        	} else if (event.getCode() == KeyCode.ENTER) {
+                info = textfield.getText();
+                dialog.close();
+        	}
         });
 
-        FlowPane pane = new FlowPane(10, 10);
-        pane.setAlignment(Pos.CENTER);
-        pane.getChildren().addAll(okButton, cancelButton);
-        VBox vBox = new VBox(10);
-        vBox.setAlignment(Pos.CENTER);
-        vBox.getChildren().addAll(label, t, pane);
-        Scene scene1 = new Scene(vBox);
-        dialog.setScene(scene1);
+        Parent buttons = makeRow(okButton, cancelButton);
+        Parent layout = makeLayout(label, textfield, buttons);
+        
+        Scene scene = new Scene(layout);
+        dialog.setScene(scene);
         dialog.showAndWait();
         return info;
     }

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
+import javafx.util.converter.NumberStringConverter;
 import smp.ImageIndex;
 import smp.ImageLoader;
 import smp.SoundfontLoader;
@@ -21,6 +22,7 @@ import smp.components.staff.clipboard.StaffRubberBand;
 import smp.components.textfield.SongNameController;
 import smp.components.topPanel.ButtonLine;
 import smp.components.topPanel.PanelButtons;
+import smp.stateMachine.StateMachine;
 
 /**
  * The Controller class for most of the program. This will handle the events
@@ -330,6 +332,9 @@ public class SMPFXController {
         
         // Fix TextField focus problems.
         new SongNameController(songName, this);
+        
+        // Bind displayed tempo to internal value in state machine
+        tempoIndicator.textProperty().bindBidirectional(StateMachine.getTempoProperty(), new NumberStringConverter());
         
     }
     /**

--- a/src/smp/presenters/api/load/Utilities.java
+++ b/src/smp/presenters/api/load/Utilities.java
@@ -446,7 +446,7 @@ public class Utilities {
 //        theStaff.setSequence(loaded);
         theStaff.setSequenceFile(inputFile);
 //        StateMachine.setTempo(loaded.getTempo());
-        theStaff.updateCurrTempo();
+//        theStaff.updateCurrTempo();
         theStaff.getControlPanel()
                 .getScrollbar()
                 .setMax(loaded.getTheLines().size()

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.input.KeyCode;
 import smp.components.Values;
 
@@ -73,7 +75,7 @@ public class StateMachine {
     /**
      * This is the current tempo that the program is running at.
      */
-    private static double tempo = Values.DEFAULT_TEMPO;
+    private static DoubleProperty tempo = new SimpleDoubleProperty(Values.DEFAULT_TEMPO);
 
 	/**
 	 * The current soundset name. This should change when a new soundfont is
@@ -142,6 +144,10 @@ public class StateMachine {
      * @return The tempo that this program is running at.
      */
     public static double getTempo() {
+        return tempo.get();
+    }
+    
+    public static DoubleProperty getTempoProperty() {
         return tempo;
     }
 
@@ -153,7 +159,7 @@ public class StateMachine {
      * @return The current tempo.
      */
     public static void setTempo(double num) {
-        tempo = num;
+        tempo.set(num);
     }
 
     /**


### PR DESCRIPTION
Some minor bug fixes:
- Undo/redo now works properly around the "Multiply tempo" feature. Before the change, undo/redo would modify the notes on the staff, but not the tempo.
- The current tempo is now stored in one place (in StateMachine). This simplifies the code as other classes are not responsible for updating several values all the time.
- Loading an arrangement with filenames that contain special characters now works. Normalizing file names is apparently unnecessary. To be safe, SMP now prevents the user from saving songs with characters that are illegal on Windows, Linux or Mac.
- Fixed a bug where an "index out of bounds" error would be raised (and caught by the JavaFX thread) whenever the mouse hovers on the far right of the staff.
- Some refactoring of common procedures in class Dialog. Also, the prompt that appears when attempting to close the program with unsaved work actually uses that class.