### PR TITLE
Fix freeze issues

### DIFF
--- a/MainWindow.fxml
+++ b/MainWindow.fxml
@@ -245,19 +245,71 @@
                               </HBox>
                     <HBox fx:id="staffPlayBars" alignment="CENTER_LEFT" layoutX="54.0" layoutY="23.0" prefHeight="448.0" prefWidth="982.0" spacing="8.0">
                       <children>
-                        <ImageView fitHeight="448.0" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
-                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" />
+                        <ImageView fitHeight="448.0" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
+                        <ImageView fitHeight="448" fitWidth="56.0" pickOnBounds="true" preserveRatio="true" visible="false">
+                          <image>
+                            <Image preserveRatio="false" smooth="false" url="@sprites/PLAY_BAR1.png" />
+                          </image>
+                        </ImageView>
                       </children>
                       <padding>
                         <Insets left="117.0" />

--- a/src/smp/SuperMarioPaint.java
+++ b/src/smp/SuperMarioPaint.java
@@ -333,25 +333,42 @@ public class SuperMarioPaint extends Application {
                     	
                     	switch(ke.getCode()) {
                     	case PAGE_UP:
+                    	    if (StateMachine.isPlaybackActive())
+                    	        break;
                     		controller.getStaff().shift(-Values.NOTELINES_IN_THE_WINDOW);
                     		break;
+                    		
                     	case PAGE_DOWN:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		controller.getStaff().shift(Values.NOTELINES_IN_THE_WINDOW);
                     		break;
+                    		
                     	case HOME:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if(ke.isControlDown())
                     			controller.getStaff().setLocation(0);
                     		break;
+                    		
                     	case END:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if(ke.isControlDown())
                     			controller.getStaff().setLocation((int)controller.getScrollbar().getMax());
                     		break;
+                    		
                     	// @since v1.4, adds A and D as controls. move to correct spot later if needed
                     	case A:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if(!ke.isControlDown() && !ke.isShiftDown())
                     			controller.getStaff().moveLeft();
+                    		
                     	// @since v1.1.2, requested by seymour
                     	case LEFT:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if (controller.getNameTextField().focusedProperty().get()) // Don't trigger while typing name
                 				break;
                     		if(ke.isControlDown() && ke.isShiftDown())
@@ -359,10 +376,16 @@ public class SuperMarioPaint extends Application {
                     		if((ke.isControlDown() && ke.getCode() != KeyCode.A) || ke.isShiftDown())
                     			controller.getStaff().shift(-4);
                     		break;
+                    		
                     	case D:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if(!ke.isControlDown() && !ke.isShiftDown())
                     			controller.getStaff().moveRight();
+
                     	case RIGHT:
+                            if (StateMachine.isPlaybackActive())
+                                break;
                     		if (controller.getNameTextField().focusedProperty().get()) // Don't trigger while typing name
                     			break;
                     		if(ke.isControlDown() && ke.isShiftDown())
@@ -419,6 +442,9 @@ public class SuperMarioPaint extends Application {
 
 			@Override
 			public void handle(ScrollEvent se) {
+                if (StateMachine.isPlaybackActive())
+                    return;
+                
 				if (se.getDeltaY() < 0) {
 					if (se.isControlDown())
 						controller.getStaff().shift(4);

--- a/src/smp/commandmanager/commands/MultiplyTempoCommand.java
+++ b/src/smp/commandmanager/commands/MultiplyTempoCommand.java
@@ -1,11 +1,9 @@
 package smp.commandmanager.commands;
 
-import java.util.ArrayList;
-
 import smp.commandmanager.CommandInterface;
 import smp.components.Values;
 import smp.components.staff.Staff;
-import smp.components.staff.sequences.StaffNoteLine;
+import smp.components.staff.sequences.StaffSequence;
 import smp.stateMachine.StateMachine;
 
 public class MultiplyTempoCommand implements CommandInterface {
@@ -24,32 +22,22 @@ public class MultiplyTempoCommand implements CommandInterface {
 	
 	@Override
 	public void redo() {
-		ArrayList<StaffNoteLine> s = theStaff.getSequence().getTheLines();
-        ArrayList<StaffNoteLine> n = new ArrayList<StaffNoteLine>();
-        for (int i = 0; i < s.size(); i++) {
-            n.add(s.get(i));
-            for (int j = 0; j < theMultiplyAmount - 1; j++)
-                n.add(new StaffNoteLine());
-        }
-        s.clear();
-        s.addAll(n);
+	    StaffSequence seq = theStaff.getSequence();
+	    seq.expand(theMultiplyAmount);
+	    seq.setTempo(newTempo);
         StateMachine.setTempo(newTempo);
         theStaff.getControlPanel().getScrollbar()
-                .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
+                .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
 	}
 
 	@Override
 	public void undo() {
-		ArrayList<StaffNoteLine> s = theStaff.getSequence().getTheLines();
-        ArrayList<StaffNoteLine> n = new ArrayList<StaffNoteLine>();
-		for (int i = 0; i < s.size(); i+= theMultiplyAmount) {
-			n.add(s.get(i));
-		}
-        s.clear();
-        s.addAll(n);
+	    StaffSequence seq = theStaff.getSequence();
+	    seq.retract(theMultiplyAmount);
+	    seq.setTempo(previousTempo);
         StateMachine.setTempo(previousTempo);
 	    theStaff.getControlPanel().getScrollbar()
-	            .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
+	            .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
 	}
 
 }

--- a/src/smp/commandmanager/commands/MultiplyTempoCommand.java
+++ b/src/smp/commandmanager/commands/MultiplyTempoCommand.java
@@ -1,7 +1,6 @@
 package smp.commandmanager.commands;
 
 import smp.commandmanager.CommandInterface;
-import smp.components.Values;
 import smp.components.staff.Staff;
 import smp.components.staff.sequences.StaffSequence;
 import smp.stateMachine.StateMachine;
@@ -26,8 +25,7 @@ public class MultiplyTempoCommand implements CommandInterface {
 	    seq.expand(theMultiplyAmount);
 	    seq.setTempo(newTempo);
         StateMachine.setTempo(newTempo);
-        theStaff.getControlPanel().getScrollbar()
-                .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
+        StateMachine.setMaxLine(seq.getLength());
 	}
 
 	@Override
@@ -36,8 +34,7 @@ public class MultiplyTempoCommand implements CommandInterface {
 	    seq.retract(theMultiplyAmount);
 	    seq.setTempo(previousTempo);
         StateMachine.setTempo(previousTempo);
-	    theStaff.getControlPanel().getScrollbar()
-	            .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
+        StateMachine.setMaxLine(seq.getLength());
 	}
 
 }

--- a/src/smp/components/buttons/ArrowButton.java
+++ b/src/smp/components/buttons/ArrowButton.java
@@ -10,6 +10,7 @@ import smp.components.general.ImagePushButton;
 import smp.components.staff.sequences.StaffNoteLine;
 import smp.components.staff.sequences.StaffSequence;
 import smp.fx.SMPFXController;
+import smp.stateMachine.StateMachine;
 import javafx.application.Platform;
 import javafx.scene.control.Slider;
 import javafx.scene.image.ImageView;
@@ -94,8 +95,7 @@ public class ArrowButton extends ImagePushButton {
             public void run() {
                 scrollbar.adjustValue(scrollbar.getValue() + skipAmount);
                 if (scrollbar.getMax() <= scrollbar.getValue() && endOfFile) {
-                    scrollbar.setMax(scrollbar.getMax()
-                            + Values.NOTELINES_IN_THE_WINDOW * 2);
+                    StateMachine.setMaxLine(StateMachine.getMaxLine() + Values.NOTELINES_IN_THE_WINDOW * 2);
                     StaffSequence s = theStaff.getSequence();
                     int start = (int) scrollbar.getMax();
                     for (int i = start; i < start

--- a/src/smp/components/buttons/ArrowButton.java
+++ b/src/smp/components/buttons/ArrowButton.java
@@ -89,6 +89,9 @@ public class ArrowButton extends ImagePushButton {
 
     /** Bumps the staff by some amount. */
     private void bumpStaff() {
+        if (StateMachine.isPlaybackActive())
+            return;
+        
         Platform.runLater(new Runnable() {
 
             @Override

--- a/src/smp/components/buttons/NewButton.java
+++ b/src/smp/components/buttons/NewButton.java
@@ -81,8 +81,7 @@ public class NewButton extends ImagePushButton {
         if (cont) {
             theStaff.setSequence(new StaffSequence());
             theStaff.setSequenceFile(null);
-            Slider sc = theStaff.getControlPanel().getScrollbar();
-            sc.setValue(0);
+            theStaff.setLocation(0);
             StateMachine.setMaxLine(Values.DEFAULT_LINES_PER_SONG);
             ArrowButton.setEndOfFile(false);
             theStaff.redraw();

--- a/src/smp/components/buttons/NewButton.java
+++ b/src/smp/components/buttons/NewButton.java
@@ -83,7 +83,7 @@ public class NewButton extends ImagePushButton {
             theStaff.setSequenceFile(null);
             Slider sc = theStaff.getControlPanel().getScrollbar();
             sc.setValue(0);
-            sc.setMax(Values.DEFAULT_LINES_PER_SONG - 10);
+            StateMachine.setMaxLine(Values.DEFAULT_LINES_PER_SONG);
             ArrowButton.setEndOfFile(false);
             theStaff.redraw();
             controller.getNameTextField().clear();

--- a/src/smp/components/buttons/NewButton.java
+++ b/src/smp/components/buttons/NewButton.java
@@ -83,7 +83,6 @@ public class NewButton extends ImagePushButton {
             theStaff.setSequenceFile(null);
             theStaff.setLocation(0);
             StateMachine.setMaxLine(Values.DEFAULT_LINES_PER_SONG);
-            ArrowButton.setEndOfFile(false);
             theStaff.redraw();
             controller.getNameTextField().clear();
             StateMachine.setSongModified(false);

--- a/src/smp/components/buttons/NewButton.java
+++ b/src/smp/components/buttons/NewButton.java
@@ -85,7 +85,7 @@ public class NewButton extends ImagePushButton {
             sc.setValue(0);
             sc.setMax(Values.DEFAULT_LINES_PER_SONG - 10);
             ArrowButton.setEndOfFile(false);
-            theStaff.getNoteMatrix().redraw();
+            theStaff.redraw();
             controller.getNameTextField().clear();
             StateMachine.setSongModified(false);
         }

--- a/src/smp/components/buttons/OptionsButton.java
+++ b/src/smp/components/buttons/OptionsButton.java
@@ -312,8 +312,7 @@ public class OptionsButton extends ImagePushButton {
             seq.expand(num);
             seq.setTempo(newTempo);
             StateMachine.setTempo(newTempo);
-            theStaff.getControlPanel().getScrollbar()
-                    .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
+            StateMachine.setMaxLine(seq.getLength());
             
             controller.getModifySongManager().execute(new MultiplyTempoCommand(theStaff, num, currTempo, newTempo));
             controller.getModifySongManager().record();

--- a/src/smp/components/buttons/OptionsButton.java
+++ b/src/smp/components/buttons/OptionsButton.java
@@ -2,7 +2,6 @@ package smp.components.buttons;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MidiUnavailableException;
@@ -31,14 +30,13 @@ import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
-import javafx.stage.StageStyle;
 import javafx.stage.Window;
 import smp.ImageLoader;
 import smp.SoundfontLoader;
 import smp.commandmanager.commands.MultiplyTempoCommand;
 import smp.components.Values;
 import smp.components.general.ImagePushButton;
-import smp.components.staff.sequences.StaffNoteLine;
+import smp.components.staff.sequences.StaffSequence;
 import smp.fx.SMPFXController;
 import smp.stateMachine.ProgramState;
 import smp.stateMachine.StateMachine;
@@ -306,20 +304,16 @@ public class OptionsButton extends ImagePushButton {
             }
             if (num <= 1)
                 return;
-            ArrayList<StaffNoteLine> s = theStaff.getSequence().getTheLines();
-            ArrayList<StaffNoteLine> n = new ArrayList<StaffNoteLine>();
-            for (int i = 0; i < s.size(); i++) {
-                n.add(s.get(i));
-                for (int j = 0; j < num - 1; j++)
-                    n.add(new StaffNoteLine());
-            }
-            s.clear();
-            s.addAll(n);
+            
+            StaffSequence seq = theStaff.getSequence();
             double currTempo = StateMachine.getTempo();
             double newTempo = currTempo * num;
+            
+            seq.expand(num);
+            seq.setTempo(newTempo);
             StateMachine.setTempo(newTempo);
             theStaff.getControlPanel().getScrollbar()
-                    .setMax(s.size() - Values.NOTELINES_IN_THE_WINDOW);
+                    .setMax(seq.getLength() - Values.NOTELINES_IN_THE_WINDOW);
             
             controller.getModifySongManager().execute(new MultiplyTempoCommand(theStaff, num, currTempo, newTempo));
             controller.getModifySongManager().record();

--- a/src/smp/components/buttons/SaveButton.java
+++ b/src/smp/components/buttons/SaveButton.java
@@ -250,31 +250,30 @@ public class SaveButton extends ImagePushButton {
      *
      * @param f_out
      *            The FileOutputStream to write in.
-     * @param out
+     * @param seq
      *            The StaffSequence to write.
      * @throws IOException
      */
-    private void saveSongTxt(FileOutputStream f_out, StaffSequence out)
+    private void saveSongTxt(FileOutputStream f_out, StaffSequence seq)
             throws IOException {
         PrintStream pr = new PrintStream(f_out);
-        ArrayList<StaffNoteLine> theLines = out.getTheLines();
-        TimeSignature t = out.getTimeSignature();
+        TimeSignature t = seq.getTimeSignature();
         if (t == null) {
             t = TimeSignature.FOUR_FOUR;
         }
-        pr.printf("TEMPO: %f, EXT: %d, TIME: %s, SOUNDSET: %s\r\n", out.getTempo(),
-                Utilities.longFromBool(out.getNoteExtensions()), t, out.getSoundset());
+        pr.printf("TEMPO: %f, EXT: %d, TIME: %s, SOUNDSET: %s\r\n", seq.getTempo(),
+                Utilities.longFromBool(seq.getNoteExtensions()), t, seq.getSoundset());
         
-        for (int i = 0; i < theLines.size(); i++) {
-            if (theLines.get(i).isEmpty()) {
+        for (int i = 0; i < seq.getLength(); i++) {
+            if (seq.getLine(i).isEmpty()) {
                 continue;
             }
             pr.print("" + (i / t.top() + 1) + ":" + (i % t.top()) + ",");
-            ArrayList<StaffNote> line = theLines.get(i).getNotes();
+            ArrayList<StaffNote> line = seq.getLine(i).getNotes();
             for (int j = 0; j < line.size(); j++) {
                 pr.print(line.get(j) + ",");
             }
-            pr.printf("VOL: %d\r\n", theLines.get(i).getVolume());
+            pr.printf("VOL: %d\r\n", seq.getLine(i).getVolume());
         }
 		pr.close();
 

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -113,7 +113,7 @@ public class Controls {
 		il = im;
 		theStaff = st;
 		setController(ct);
-		setScrollbar(controller.getScrollbar());
+		scrollbar = controller.getScrollbar();
 		theList = controller.getArrangementList();
 		initializeArrows();
 		initializeControlButtons();
@@ -345,23 +345,6 @@ public class Controls {
 	 */
 	public OptionsButton getOptionsButton() {
 		return options;
-	}
-
-	/**
-	 * Sets the scollbar that we will be using.
-	 *
-	 * @param scroll
-	 *            The slider that we'll be using.
-	 */
-	public void setScrollbar(Slider scroll) {
-		scrollbar = scroll;
-	}
-
-	/**
-	 * @return The scrollbar of the program.
-	 */
-	public Slider getScrollbar() {
-		return scrollbar;
 	}
 
 	/**

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -253,8 +253,8 @@ public class Controls {
 
 			@Override
 			public void changed(ObservableValue<? extends Number> arg0, Number oldVal, Number newVal) {
-				StateMachine.setMeasureLineNum(newVal.intValue());
 				theStaff.setLocation(newVal.intValue());
+				theStaff.redraw();
 				theStaff.getStaffImages().updateStaffMeasureLines(newVal.intValue());
 			}
 

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -116,7 +116,6 @@ public class Controls {
 		setScrollbar(controller.getScrollbar());
 		theList = controller.getArrangementList();
 		initializeArrows();
-		initializeScrollbar();
 		initializeControlButtons();
 		initializeTempoButtons();
 		initializeLoadSaveButtons();
@@ -245,20 +244,6 @@ public class Controls {
 		rightArrow.setStaff(theStaff);
 		rightFastArrow.setStaff(theStaff);
 		leftFastArrow.setStaff(theStaff);
-	}
-
-	/** Sets up the scollbar to affect the staff in some way. */
-	private void initializeScrollbar() {
-		scrollbar.valueProperty().addListener(new ChangeListener<Number>() {
-
-			@Override
-			public void changed(ObservableValue<? extends Number> arg0, Number oldVal, Number newVal) {
-				theStaff.setLocation(newVal.intValue());
-				theStaff.redraw();
-				theStaff.getStaffImages().updateStaffMeasureLines(newVal.intValue());
-			}
-
-		});
 	}
 
 	/**

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -8,7 +8,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
-import javafx.scene.control.Slider;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Window;
@@ -78,9 +77,6 @@ public class Controls {
 	/** The pointer to the clipboard selection button on the staff. */
 	private ClipboardButton clipboard;
 
-	/** This is the slider at the bottom of the screen. */
-	private Slider scrollbar;
-
 	/** The arrow that you click to go left. */
 	private ArrowButton leftArrow;
 
@@ -113,7 +109,6 @@ public class Controls {
 		il = im;
 		theStaff = st;
 		setController(ct);
-		scrollbar = controller.getScrollbar();
 		theList = controller.getArrangementList();
 		initializeArrows();
 		initializeControlButtons();
@@ -226,19 +221,19 @@ public class Controls {
 	 * Sets up the slider and arrows that the controls will have.
 	 */
 	private void initializeArrows() {
-		leftArrow = new ArrowButton(controller.getLeftArrow(), scrollbar, ImageIndex.SCROLLBAR_LEFT1_PRESSED,
+		leftArrow = new ArrowButton(controller.getLeftArrow(), ImageIndex.SCROLLBAR_LEFT1_PRESSED,
 				ImageIndex.SCROLLBAR_LEFT1, controller, il);
-		rightArrow = new ArrowButton(controller.getRightArrow(), scrollbar, ImageIndex.SCROLLBAR_RIGHT1_PRESSED,
+		rightArrow = new ArrowButton(controller.getRightArrow(), ImageIndex.SCROLLBAR_RIGHT1_PRESSED,
 				ImageIndex.SCROLLBAR_RIGHT1, controller, il);
-		leftFastArrow = new ArrowButton(controller.getLeftFastArrow(), scrollbar, ImageIndex.SCROLLBAR_LEFT2_PRESSED,
+		leftFastArrow = new ArrowButton(controller.getLeftFastArrow(), ImageIndex.SCROLLBAR_LEFT2_PRESSED,
 				ImageIndex.SCROLLBAR_LEFT2, controller, il);
-		rightFastArrow = new ArrowButton(controller.getRightFastArrow(), scrollbar, ImageIndex.SCROLLBAR_RIGHT2_PRESSED,
+		rightFastArrow = new ArrowButton(controller.getRightFastArrow(), ImageIndex.SCROLLBAR_RIGHT2_PRESSED,
 				ImageIndex.SCROLLBAR_RIGHT2, controller, il);
 
 		leftArrow.setSkipAmount(-1);
 		rightArrow.setSkipAmount(1);
-		rightFastArrow.setSkipAmount(Double.MAX_VALUE);
-		leftFastArrow.setSkipAmount(-Double.MAX_VALUE);
+		rightFastArrow.setSkipAmount(Integer.MAX_VALUE);
+		leftFastArrow.setSkipAmount(-Integer.MAX_VALUE);
 
 		leftArrow.setStaff(theStaff);
 		rightArrow.setStaff(theStaff);

--- a/src/smp/components/controls/Controls.java
+++ b/src/smp/components/controls/Controls.java
@@ -118,7 +118,6 @@ public class Controls {
 		initializeArrows();
 		initializeScrollbar();
 		initializeControlButtons();
-		theStaff.setCurrVal(scrollbar.valueProperty());
 		initializeTempoButtons();
 		initializeLoadSaveButtons();
 		initializeNewButton();

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -263,23 +263,23 @@ public class Utilities {
                         }
                     }
                 }
-                if (loaded.getTheLines().size() < lineNum + 1) {
-                    int add = lineNum - loaded.getTheLines().size();
+                if (loaded.getLength() < lineNum + 1) {
+                    int add = lineNum - loaded.getLength();
                     for (int i = 0; i < add; i++) {
                         loaded.addLine(new StaffNoteLine());
                     }
                 }
-                if (lineNum >= loaded.getTheLines().size()) {
+                if (lineNum >= loaded.getLength()) {
                     loaded.addLine(st);
                 } else {
                     loaded.setLine(lineNum, st);
                 }
             }
         }
-        if (loaded.getTheLines().size() % 10 != 0) {
+        if (loaded.getLength() % 10 != 0) {
             do {
                 loaded.addLine(new StaffNoteLine());
-            } while (loaded.getTheLines().size() % 10 != 0);
+            } while (loaded.getLength() % 10 != 0);
         }
         return loaded;
     }
@@ -438,7 +438,7 @@ public class Utilities {
         StateMachine.setTempo(loaded.getTempo());
         theStaff.getControlPanel()
                 .getScrollbar()
-                .setMax(loaded.getTheLines().size()
+                .setMax(loaded.getLength()
                         - Values.NOTELINES_IN_THE_WINDOW);
         theStaff.setLocation(0);
         theStaff.getNoteMatrix().redraw();

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -413,7 +413,7 @@ public class Utilities {
                 .setMax(loaded.getLength()
                         - Values.NOTELINES_IN_THE_WINDOW);
         theStaff.setLocation(0);
-        theStaff.getNoteMatrix().redraw();
+        theStaff.redraw();
         String fname = inputFile.getName();
         try {
             if (mpc)

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -408,10 +408,7 @@ public class Utilities {
         theStaff.setSequence(loaded);
         theStaff.setSequenceFile(inputFile);
         StateMachine.setTempo(loaded.getTempo());
-        theStaff.getControlPanel()
-                .getScrollbar()
-                .setMax(loaded.getLength()
-                        - Values.NOTELINES_IN_THE_WINDOW);
+        StateMachine.setMaxLine(loaded.getLength());
         theStaff.setLocation(0);
         theStaff.redraw();
         String fname = inputFile.getName();

--- a/src/smp/components/general/Utilities.java
+++ b/src/smp/components/general/Utilities.java
@@ -141,34 +141,6 @@ public class Utilities {
     }
 
     /**
-     * Makes a sequence fit on the screen, and also trims excessive whitespace
-     * at the end of a file.
-     *
-     * @param theSeq
-     *            The sequence to normalize.
-     */
-    public static void normalize(StaffSequence theSeq) {
-        ArrayList<StaffNoteLine> theLines = theSeq.getTheLines();
-        int last = theLines.size() - 1;
-        for (int i = theLines.size() - 1; i >= 0; i--) {
-            if (i < Values.DEFAULT_LINES_PER_SONG)
-                break;
-            else if (!theLines.get(i).isEmpty()) {
-                last = i;
-                break;
-            }
-        }
-        last = theLines.size() - last;
-        for (int i = 0; i < last - 1; i++)
-            theLines.remove(theLines.size() - 1);
-        while (theLines.size() % 4 != 0
-                || theLines.size() % Values.NOTELINES_IN_THE_WINDOW != 0) {
-            theLines.add(new StaffNoteLine());
-        }
-
-    }
-
-    /**
      * Loads a song from the file specified.
      *
      * @param inputFile
@@ -432,7 +404,7 @@ public class Utilities {
 	 */
     public static String populateStaff(StaffSequence loaded, File inputFile,
             boolean mpc, Staff theStaff, SMPFXController controller) {
-        Utilities.normalize(loaded);
+        loaded.normalize();
         theStaff.setSequence(loaded);
         theStaff.setSequenceFile(inputFile);
         StateMachine.setTempo(loaded.getTempo());

--- a/src/smp/components/staff/NoteMatrix.java
+++ b/src/smp/components/staff/NoteMatrix.java
@@ -177,7 +177,7 @@ public class NoteMatrix {
         StaffVolumeEventHandler sveh = volumeBarHandlers.get(index);
         int currentPosition = StateMachine.getMeasureLineNum();
 
-        StaffNoteLine stl = theStaff.getSequence().getLine(
+        StaffNoteLine stl = theStaff.getSequence().getLineSafe(
                 currentPosition + index);
 
         updateVolumeDisplay(sveh, stl);

--- a/src/smp/components/staff/SoundPlayer.java
+++ b/src/smp/components/staff/SoundPlayer.java
@@ -48,7 +48,7 @@ public class SoundPlayer {
     public void playSoundLine(int index) {
         if (!run)
             return;
-        StaffNoteLine s = theStaff.getSequence().getLine(
+        StaffNoteLine s = theStaff.getSequence().getLineSafe(
                 (int) (getCurrVal() + index));
         ArrayList<StaffNote> theNotes = s.getNotes();
         tracker.stopNotes(s);

--- a/src/smp/components/staff/SoundPlayer.java
+++ b/src/smp/components/staff/SoundPlayer.java
@@ -8,6 +8,7 @@ import smp.components.InstrumentIndex;
 import smp.components.Values;
 import smp.components.staff.sequences.StaffNote;
 import smp.components.staff.sequences.StaffNoteLine;
+import smp.stateMachine.StateMachine;
 
 /**
  *
@@ -37,10 +38,6 @@ public class SoundPlayer {
     public SoundPlayer(Staff s) {
         theStaff = s;
     }
-    
-    private double getCurrVal() {
-        return theStaff.getCurrVal().doubleValue();
-    }
 
     /**
      * Plays the current line of notes.
@@ -49,7 +46,7 @@ public class SoundPlayer {
         if (!run)
             return;
         StaffNoteLine s = theStaff.getSequence().getLineSafe(
-                (int) (getCurrVal() + index));
+                StateMachine.getMeasureLineNum() + index);
         ArrayList<StaffNote> theNotes = s.getNotes();
         tracker.stopNotes(s);
         for (StaffNote sn : theNotes) {

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -11,7 +11,6 @@ import javax.sound.midi.MidiChannel;
 import javax.sound.midi.MidiUnavailableException;
 
 import javafx.application.Platform;
-import javafx.beans.property.DoubleProperty;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.scene.control.ListView;
@@ -58,9 +57,6 @@ public class Staff {
 
     /** Whether we are playing an arrangement. */
     private boolean arrPlaying = false;
-
-    /** This is the current line that we are at. */
-    private DoubleProperty currVal;
 
     /** These are the play button, stop button, etc. */
     private Controls theControls;
@@ -539,23 +535,6 @@ public class Staff {
     }
 
     /**
-     * Sets the DoubleProperty value that we change to move the staff.
-     *
-     * @param d
-     *            The DoubleProperty that we want to set.
-     */
-    public void setCurrVal(DoubleProperty d) {
-        currVal = d;
-    }
-
-    /**
-     * @return The DoubleProperty value that we change to move the staff.
-     */
-    public DoubleProperty getCurrVal() {
-        return currVal;
-    }
-
-    /**
      * @return The Staff's Image Loader
      */
     public ImageLoader getImageLoader() {
@@ -577,7 +556,7 @@ public class Staff {
      */
     private void doEvents(int index) {
         StaffNoteLine s = getSequence().getLineSafe(
-                (int) (currVal.doubleValue() + index));
+                StateMachine.getMeasureLineNum() + index);
         ArrayList<StaffEvent> theEvents = s.getEvents();
         for (StaffEvent e : theEvents) {
             e.doEvent(this);
@@ -631,7 +610,7 @@ public class Staff {
                     @Override
                     public void run() {
                         setLocation(0);
-                        currVal.setValue(0);
+                        StateMachine.setMeasureLineNum(0);
                         playBars.get(0).setVisible(true);
                         for (int i = 1; i < playBars.size(); i++)
                             playBars.get(i).setVisible(false);
@@ -712,10 +691,10 @@ public class Staff {
                     public void run() {
                         bumpHighlights(playBars, index);
                         if (advance) {
-                            int loc = (int) currVal.getValue().doubleValue()
+                            int loc = StateMachine.getMeasureLineNum()
                                     + Values.NOTELINES_IN_THE_WINDOW;
                             setLocation(loc);
-                            currVal.setValue(loc);
+                            StateMachine.setMeasureLineNum(loc);
                         }
                         doEvents(index);
                         playSoundLine(index);

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -743,7 +743,6 @@ public class Staff {
                     while (queue > 0)
                         ;
                     /* Force emptying of queue before changing songs. */
-                    queue++;
                     setSoundset(seq.get(i).getSoundset());
                     index = 0;
                     advance = false;
@@ -795,22 +794,15 @@ public class Staff {
 			 *            The soundset.
 			 * @since v1.1.2
 			 */
-			private void setSoundset(final String soundset) {
-				Platform.runLater(new Runnable() {
-
-					@Override
-					public void run() {
-						if (!controller.getSoundfontLoader().loadFromCache(soundset)) {
-							try {
-								controller.getSoundfontLoader().loadFromAppData(soundset);
-							} catch (InvalidMidiDataException | IOException | MidiUnavailableException e) {
-								e.printStackTrace();
-							}
-							controller.getSoundfontLoader().storeInCache();
-						}
-						queue--;
-					}
-				});
+            private void setSoundset(final String soundset) {
+                if (!controller.getSoundfontLoader().loadFromCache(soundset)) {
+                    try {
+                        controller.getSoundfontLoader().loadFromAppData(soundset);
+                    } catch (InvalidMidiDataException | IOException | MidiUnavailableException e) {
+                        e.printStackTrace();
+                    }
+                    controller.getSoundfontLoader().storeInCache();
+                }
 			}
 
             /**

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -647,6 +647,9 @@ public class Staff {
                 int counter = StateMachine.getMeasureLineNum();
                 boolean zero = false;
                 int endLine = theSequence.getEndlineIndex();
+                
+                theSequence.normalize();
+                
                 while (songPlaying) {
                     if (zero) {
                         queue++;
@@ -686,13 +689,9 @@ public class Staff {
              */
             protected void playNextLine() {
                 runUI(playBars, index, advance);
-                advance = !(index < Values.NOTELINES_IN_THE_WINDOW - 1);
-                int remain = (int) (theControls.getScrollbar().getMax() - currVal.intValue());
-                if (Values.NOTELINES_IN_THE_WINDOW > remain && advance) {
-                    index -= (remain - 1);
-                } else {
-                    index = advance ? 0 : (index + 1);
-                }
+                
+                advance = index >= Values.NOTELINES_IN_THE_WINDOW - 1;
+                index = advance ? 0 : (index + 1);
             }
 
             /**
@@ -766,6 +765,10 @@ public class Staff {
                 ArrayList<StaffSequence> seq = theArrangement.getTheSequences();
                 ArrayList<File> files = theArrangement.getTheSequenceFiles();
                 int endLine;
+                
+                for (StaffSequence s : seq)
+                    s.normalize();
+                
                 for (int i = 0; i < seq.size(); i++) {
                     while (queue > 0)
                         ;

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -673,6 +673,7 @@ public class Staff {
 
             @Override
             protected Staff call() throws Exception {
+                StateMachine.setArrangementSongIndex(0);
                 ArrayList<StaffSequence> seq = theArrangement.getTheSequences();
                 ArrayList<File> files = theArrangement.getTheSequenceFiles();
                 int endLine;
@@ -687,8 +688,7 @@ public class Staff {
                     setSoundset(seq.get(i).getSoundset());
                     index = 0;
                     advance = false;
-                    queue++;
-                    highlightSong(i);
+                    StateMachine.setArrangementSongIndex(i);
                     theSequence = seq.get(i);
                     theSequenceFile = files.get(i);
                     StateMachine.setNoteExtensions(
@@ -743,26 +743,6 @@ public class Staff {
                     controller.getSoundfontLoader().storeInCache();
                 }
 			}
-
-            /**
-             * Highlights the currently-playing song in the arranger list.
-             *
-             * @param i
-             *            The index to highlight.
-             */
-            private void highlightSong(final int i) {
-                Platform.runLater(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        theArrangementList.getSelectionModel().select(i);
-                        setSequenceName(theArrangementList.getSelectionModel().getSelectedItem());
-                        theArrangementList.scrollTo(i);
-                        queue--;
-                    }
-
-                });
-            }
         }
     }
 }

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -194,8 +194,6 @@ public class Staff {
             @Override
             public void run() {
                 theMatrix.redraw();
-                Slider s = controller.getScrollbar();
-                s.adjustValue(StateMachine.getMeasureLineNum());
             }
         });
     }

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -867,7 +867,7 @@ public class Staff {
                     @Override
                     public void run() {
                         theControls.getScrollbar().setMax(
-                                theSequence.getTheLines().size()
+                                theSequence.getLength()
                                         - Values.NOTELINES_IN_THE_WINDOW);
                         queue--;
                     }

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -222,12 +222,6 @@ public class Staff {
     	theControls.getPlayButton().reactPressed(null); // Presses the play button when starting the song. - seymour
         soundPlayer.setRun(true);
         highlightsOff();
-        int endLine = theSequence.getEndlineIndex();
-        if ((endLine < 0 && theSequence.getLine(0).isEmpty())
-                || (endLine <= StateMachine.getMeasureLineNum())) {
-            theControls.getStopButton().reactPressed(null);
-            return;
-        }
         songPlaying = true;
         setTempo(StateMachine.getTempo());
         animationService.restart();

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -619,6 +619,7 @@ public class Staff {
                 int endLine = theSequence.getEndlineIndex();
                 
                 theSequence.normalize();
+                StateMachine.setMaxLine(theSequence.getLength());
                 
                 while (songPlaying) {
                     if (zero) {
@@ -754,8 +755,7 @@ public class Staff {
                             theSequence.getNoteExtensions());
                     controller.getInstBLine().updateNoteExtensions();
                     StateMachine.setTempo(theSequence.getTempo());
-                    queue++;
-                    setScrollbar();
+                    StateMachine.setMaxLine(theSequence.getLength());
                     endLine = seq.get(i).getEndlineIndex();
                     songPlaying = true;
                     setTempo(theSequence.getTempo());
@@ -830,19 +830,6 @@ public class Staff {
                         queue--;
                     }
 
-                });
-            }
-
-            /** Sets the scrollbar max/min to the proper values. */
-            private void setScrollbar() {
-                Platform.runLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        theControls.getScrollbar().setMax(
-                                theSequence.getLength()
-                                        - Values.NOTELINES_IN_THE_WINDOW);
-                        queue--;
-                    }
                 });
             }
         }

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -180,7 +180,6 @@ public class Staff {
      *            is to be displayed.
      */
     public synchronized void setLocation(int num) {
-        theMatrix.redraw();
         int maxVal = StateMachine.getMaxLine() - Values.NOTELINES_IN_THE_WINDOW;
         int newLoc = (num < 0) ? 0 : (num > maxVal) ? maxVal : num;
         StateMachine.setMeasureLineNum(newLoc);
@@ -190,12 +189,7 @@ public class Staff {
      * Force re-draws the staff.
      */
     public synchronized void redraw() {
-        Platform.runLater(new Runnable() {
-            @Override
-            public void run() {
-                theMatrix.redraw();
-            }
-        });
+        Platform.runLater(() -> theMatrix.redraw());
     }
 
     /** Turns off all highlights in the play bars in the staff. */

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -576,7 +576,7 @@ public class Staff {
      * @param index The index to do events from
      */
     private void doEvents(int index) {
-        StaffNoteLine s = getSequence().getLine(
+        StaffNoteLine s = getSequence().getLineSafe(
                 (int) (currVal.doubleValue() + index));
         ArrayList<StaffEvent> theEvents = s.getEvents();
         for (StaffEvent e : theEvents) {

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -596,12 +596,11 @@ public class Staff {
              * Zeros the staff to the beginning point. Use only at the beginning
              * of a new song file.
              */
-            protected void zeroEverything() {
+            protected void zeroHighlights() {
                 Platform.runLater(new Runnable() {
 
                     @Override
                     public void run() {
-                        setLocation(0);
                         playBars.get(0).setVisible(true);
                         for (int i = 1; i < playBars.size(); i++)
                             playBars.get(i).setVisible(false);
@@ -623,8 +622,9 @@ public class Staff {
                 
                 while (songPlaying) {
                     if (zero) {
+                        setLocation(0);
                         queue++;
-                        zeroEverything();
+                        zeroHighlights();
                         while (queue > 0)
                             ;
                         zero = false;
@@ -763,7 +763,7 @@ public class Staff {
                     int counter = 0;
                     setLocation(0);
                     queue++;
-                    zeroEverything();
+                    zeroHighlights();
                     while (queue > 0)
                         ;
                     /* Force operations to complete before starting a song. */

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -581,19 +581,22 @@ public class Staff {
                 
                 theSequence.normalize();
                 StateMachine.setMaxLine(theSequence.getLength());
+
+                queue = 0;
                 
                 while (songPlaying) {
                     StateMachine.setPlaybackPosition(index);
                     
                     if (zero) {
                         setLocation(0);
-                        while (queue > 0)
-                            ;
+                        while (queue > 0);
                         zero = false;
                     }
+                    
                     queue++;
                     playNextLine();
                     counter++;
+                    
                     if (counter >= endLine) {
                         if (StateMachine.isLoopPressed()) {
                             counter = 0;
@@ -604,6 +607,7 @@ public class Staff {
                             songPlaying = false;
                         }
                     }
+                    
                     try {
                         Thread.sleep(delayMillis, delayNanos);
                     } catch (InterruptedException e) {
@@ -680,11 +684,10 @@ public class Staff {
                 
                 for (StaffSequence s : seq)
                     s.normalize();
+
+                queue = 0;
                 
                 for (int i = 0; i < seq.size(); i++) {
-                    while (queue > 0)
-                        ;
-                    /* Force emptying of queue before changing songs. */
                     setSoundset(seq.get(i).getSoundset());
                     index = 0;
                     advance = false;
@@ -701,9 +704,7 @@ public class Staff {
                     setTempo(theSequence.getTempo());
                     int counter = 0;
                     setLocation(0);
-                    while (queue > 0)
-                        ;
-                    /* Force operations to complete before starting a song. */
+
                     while (songPlaying && arrPlaying) {
                         StateMachine.setPlaybackPosition(index);
 
@@ -719,8 +720,12 @@ public class Staff {
                             // Do nothing
                         }
                     }
+                    
                     if (!arrPlaying)
                         break;
+
+                    /* Force emptying of queue before changing songs. */
+                    while (queue > 0);
                 }
                 hitStop();
                 return theMatrix.getStaff();

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -641,6 +641,9 @@ public class Staff {
              *            Whether we need to move the staff by some bit.
              */
             private void runUI(final int index, final boolean advance) {
+                // In principle it's not necessary to send this job to the FXAT,
+                // but for some reason the program is more stable that way
+                // Leaving things as they are until someone can figure it out --rozlyn
                 Platform.runLater(new Runnable() {
 
                     @Override

--- a/src/smp/components/staff/Staff.java
+++ b/src/smp/components/staff/Staff.java
@@ -14,7 +14,6 @@ import javafx.application.Platform;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.scene.control.ListView;
-import javafx.scene.control.Slider;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import smp.ImageIndex;
@@ -182,8 +181,9 @@ public class Staff {
      */
     public synchronized void setLocation(int num) {
         theMatrix.redraw();
-        Slider s = controller.getScrollbar();
-        s.adjustValue(num);
+        int maxVal = StateMachine.getMaxLine() - Values.NOTELINES_IN_THE_WINDOW;
+        int newLoc = (num < 0) ? 0 : (num > maxVal) ? maxVal : num;
+        StateMachine.setMeasureLineNum(newLoc);
     }
 
     /**
@@ -608,7 +608,6 @@ public class Staff {
                     @Override
                     public void run() {
                         setLocation(0);
-                        StateMachine.setMeasureLineNum(0);
                         playBars.get(0).setVisible(true);
                         for (int i = 1; i < playBars.size(); i++)
                             playBars.get(i).setVisible(false);
@@ -692,7 +691,6 @@ public class Staff {
                             int loc = StateMachine.getMeasureLineNum()
                                     + Values.NOTELINES_IN_THE_WINDOW;
                             setLocation(loc);
-                            StateMachine.setMeasureLineNum(loc);
                         }
                         doEvents(index);
                         playSoundLine(index);
@@ -769,7 +767,7 @@ public class Staff {
                     setTempo(theSequence.getTempo());
                     playBars = staffImages.getPlayBars();
                     int counter = 0;
-                    StateMachine.setMeasureLineNum(0);
+                    setLocation(0);
                     queue++;
                     zeroEverything();
                     while (queue > 0)

--- a/src/smp/components/staff/StaffImages.java
+++ b/src/smp/components/staff/StaffImages.java
@@ -105,7 +105,7 @@ public class StaffImages {
         for (int i = 0; i < Values.NOTELINES_IN_THE_WINDOW; i++) {
             StaffVolumeEventHandler sveh = theStaff.getNoteMatrix()
                     .getVolHandler(i);
-            StaffNoteLine stl = theStaff.getSequence().getLine(i);
+            StaffNoteLine stl = theStaff.getSequence().getLineSafe(i);
             sveh.setStaffNoteLine(stl);
         }
     }

--- a/src/smp/components/staff/StaffImages.java
+++ b/src/smp/components/staff/StaffImages.java
@@ -40,9 +40,6 @@ public class StaffImages {
      */
     private ArrayList<Text> measureNums;
 
-    /** These are the bars that highlight notes. */
-    private ArrayList<ImageView> staffPlayBars;
-
     /** This is the FXML controller class. */
     private SMPFXController controller;
 
@@ -90,7 +87,6 @@ public class StaffImages {
     public void initialize() {
 
         initializeStaffMeasureLines(controller.getStaffMeasureLines());
-        initializeStaffPlayBars(controller.getStaffPlayBars());
         initializeStaffMeasureNums(controller.getStaffMeasureNums());
         initializeStaffLedgerLines();
         initializeStaffInstruments(controller.getStaffInstruments(),
@@ -239,22 +235,6 @@ public class StaffImages {
     }
 
     /**
-     * Sets up the note highlighting functionality.
-     *
-     * @param staffPlayBars
-     *            The bars that move to highlight different notes.
-     */
-    private void initializeStaffPlayBars(HBox playBars) {
-        staffPlayBars = new ArrayList<ImageView>();
-        for (Node n : playBars.getChildren()) {
-            ImageView i = (ImageView) n;
-            i.setImage(il.getSpriteFX(ImageIndex.PLAY_BAR1));
-            i.setVisible(false);
-            staffPlayBars.add(i);
-        }
-    }
-
-    /**
      * Sets up the staff expansion lines, which are to hold notes that are
      * higher than or lower than the regular lines of the staff.
      *
@@ -299,14 +279,6 @@ public class StaffImages {
      */
     public void setStaff(Staff s) {
         theStaff = s;
-    }
-
-    /**
-     * @return The list of <code>ImageView</code> objects that holds the bars
-     *         that will highlight the notes that we are playing on the staff.
-     */
-    public ArrayList<ImageView> getPlayBars() {
-        return staffPlayBars;
     }
 
     /**

--- a/src/smp/components/staff/StaffInstrumentEventHandler.java
+++ b/src/smp/components/staff/StaffInstrumentEventHandler.java
@@ -300,7 +300,7 @@ public class StaffInstrumentEventHandler implements EventHandler<Event> {
         if (!accList.contains(accidental))
             accList.add(accidental);
 
-        StaffNoteLine temp = theStaff.getSequence().getLine(
+        StaffNoteLine temp = theStaff.getSequence().getLineSafe(
                 line + StateMachine.getMeasureLineNum());
 
         if (temp.isEmpty()) {
@@ -346,7 +346,7 @@ public class StaffInstrumentEventHandler implements EventHandler<Event> {
         if (!accList.isEmpty())
             accList.remove(0);
 
-        StaffNoteLine temp = theStaff.getSequence().getLine(
+        StaffNoteLine temp = theStaff.getSequence().getLineSafe(
                 line + StateMachine.getMeasureLineNum());
 
         if (!temp.isEmpty()) {

--- a/src/smp/components/staff/clipboard/StaffClipboardAPI.java
+++ b/src/smp/components/staff/clipboard/StaffClipboardAPI.java
@@ -214,6 +214,7 @@ public class StaffClipboardAPI {
 
         theStaff.redraw();
         commandManager.record();
+        StateMachine.setMaxLine(theStaff.getSequence().getLength());
 	}
 
 	/**

--- a/src/smp/components/staff/clipboard/StaffClipboardAPI.java
+++ b/src/smp/components/staff/clipboard/StaffClipboardAPI.java
@@ -124,7 +124,7 @@ public class StaffClipboardAPI {
 			int line = noteLine.getKey();
 			ArrayList<StaffNote> ntList = noteLine.getValue().getNotes();
 			
-			StaffNoteLine lineDest = theStaff.getSequence().getLine(line);
+			StaffNoteLine lineDest = theStaff.getSequence().getLineSafe(line);
 			
 			for(StaffNote note : ntList){
 				lineDest.remove(note);
@@ -160,7 +160,7 @@ public class StaffClipboardAPI {
 		for (Map.Entry<Integer, StaffNoteLine> lineCopy : copiedData.entrySet()) {
 			int line = lineMoveTo + lineCopy.getKey();
 			
-			StaffNoteLine lineDest = theStaff.getSequence().getLine(line);
+			StaffNoteLine lineDest = theStaff.getSequence().getLineSafe(line);
 			StaffNoteLine lineSrc = lineCopy.getValue();
 			for(StaffNote note : lineSrc.getNotes()) {
 				
@@ -231,7 +231,7 @@ public class StaffClipboardAPI {
 		StaffClipboardFilter instFilter = theStaffClipboard.getInstrumentFilter();
 
 		for (int line = lineBegin; line <= lineEnd; line++) {
-			StaffNoteLine lineSrc = theStaff.getSequence().getLine(line);
+			StaffNoteLine lineSrc = theStaff.getSequence().getLineSafe(line);
 
 			ArrayList<StaffNote> ntList = lineSrc.getNotes();
 			for (StaffNote note : ntList) {

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -167,6 +167,47 @@ public class StaffSequence implements Serializable {
     public void addLine(StaffNoteLine s) {
         theLines.add(s);
     }
+    
+    /**
+     * <p>Insert empty lines to implement the "Multiply Tempo" feature.</p>
+     */
+    public void expand(int n) {
+        if (n < 2 || theLines.isEmpty())
+            return;
+        
+        int sz = theLines.size();
+        for (int i = 0; i < sz; i++) {
+            int idx = (i * n) + 1;
+            for (int j = 0; j < n - 1; j++)
+                theLines.add(idx, new StaffNoteLine());
+        }
+    }
+    
+    /**
+     * <p>Remove the empty lines resulting from {@link expand}.</p>
+     * @throws IllegalArgumentException when attempting to remove a non empty line.
+     */
+    public void retract(int n) throws IllegalArgumentException {
+        if (n < 2 || theLines.isEmpty())
+            return;
+        
+        int sz = theLines.size();
+        // Check there is no error before modifying the list
+        for (int i = 0; i < sz; i++) {
+            if (i % n == 0)
+                continue;
+            
+            if (!theLines.get(i).isEmpty())
+                throw new IllegalArgumentException("Can't undo Multiply Tempo");
+        }
+        
+        for (int i = sz - 1; i >= 0; i--) {
+            if (i % n == 0)
+                continue;
+            
+            theLines.remove(i);
+        }
+    }
 
     /**
      * Adds a line into this sequence.

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -81,18 +81,25 @@ public class StaffSequence implements Serializable {
             return barLength * ((lastNonempty / barLength) + 1);
         }
     }
+    
+    public StaffNoteLine getLine(int i) throws IndexOutOfBoundsException {
+        return theLines.get(i);
+    }
 
     /**
-     * @param i
-     *            The index that we want to get some line from.
-     * @return Gets a <code>StaffNoteLine</code> that resides at index i.
+     * <p>Safe version of {@link getLine} that resizes the sequence if the
+     * index is out of bounds.</p>
+     * 
+     * <p>If the sequence's length is bound to UI behavior in some way, it is
+     * recommended to use {@link getLine} instead, as calling this method may
+     * have unexpected consequences on the UI side.
      */
-    public StaffNoteLine getLine(int i) {
+    public StaffNoteLine getLineSafe(int i) {
         try {
             return theLines.get(i);
         } catch (IndexOutOfBoundsException e) {
             resize(i + 1);
-            return getLine(i);
+            return getLineSafe(i);
         }
     }
 

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -2,6 +2,7 @@ package smp.components.staff.sequences;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 import smp.components.Values;
 import smp.stateMachine.TimeSignature;
@@ -26,7 +27,7 @@ public class StaffSequence implements Serializable {
     private double tempo = Values.DEFAULT_TEMPO;
 
     /** These are all of the lines on the staff. */
-    private ArrayList<StaffNoteLine> theLines;
+    private List<StaffNoteLine> theLines;
 
     /** This tells us which notes are extended (green highlight) or not. */
     private boolean[] noteExtensions = new boolean[Values.NUMINSTRUMENTS];
@@ -139,13 +140,6 @@ public class StaffSequence implements Serializable {
             resize(i + 1);
             return getLineSafe(i);
         }
-    }
-
-    /**
-     * @return The entire list of the StaffNoteLines of this song.
-     */
-    public ArrayList<StaffNoteLine> getTheLines() {
-        return theLines;
     }
 
     /**

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -47,6 +47,26 @@ public class StaffSequence implements Serializable {
     public int getLength() {
         return theLines.size();
     }
+    
+    /**
+     * <p>Compute the index of the line marking the end of this sequence,
+     * <i>i.e.</i> the first line that should <b>not</b> be played.</p>
+     * 
+     * <p>Takes into account the time signature (length of a bar).</p>
+     */
+    public int getEndlineIndex() {
+        int lastNonempty = theLines.size() - 1;
+        while (lastNonempty >= 0 && theLines.get(lastNonempty).isEmpty()) {
+            lastNonempty--;
+        }
+        if (lastNonempty < 0) {
+            return 0;
+        } else {
+            int barLength = t.top();
+            // return first multiple of barLength that is > lastNonempty
+            return barLength * ((lastNonempty / barLength) + 1);
+        }
+    }
 
     /**
      * @param i

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -43,6 +43,10 @@ public class StaffSequence implements Serializable {
         for (int i = 0; i < Values.DEFAULT_LINES_PER_SONG; i++)
             theLines.add(new StaffNoteLine());
     }
+    
+    public int getLength() {
+        return theLines.size();
+    }
 
     /**
      * @param i

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -82,6 +82,44 @@ public class StaffSequence implements Serializable {
         }
     }
     
+    /**
+     * <p>Resize the sequence so that the display won't show any lines beyond the
+     * sequence's size while the player is running.</p>
+     * 
+     * <p>The result is some <i>n</i> such that:</p>
+     * <ul>
+     * <li><i>n</i> is greater than or equal to the minimal sequence size;</li>
+     * <li><i>n</i> is greater than or equal to the result of {@link getEndlineIndex};</li>
+     * <li><i>n</i> is a multiple of this sequence's bar length;</li>
+     * <li>If <i>k</i> consecutive screens are necessary to display the whole sequence,
+     * and one screen is <i>p</i>-wide, then <i>n</i> is greater than or equal to
+     * <i>(k+1)*p</i></li>
+     * <li><i>n</i> is minimal for the conditions above.</li>
+     * </ul>
+     */
+    public void normalize() {
+        int endline = getEndlineIndex();
+        int barLength = t.top();
+        
+        int screenWidth = Values.NOTELINES_IN_THE_WINDOW;
+        int numberOfScreens = (endline / screenWidth) + 1;
+        
+        int n = endline;
+        if (n < Values.DEFAULT_LINES_PER_SONG)
+            n = Values.DEFAULT_LINES_PER_SONG;
+        
+        // "+1" in case one additional screen is necessary; this can happen if a
+        // song is played from the middle
+        if (n < (numberOfScreens + 1) * screenWidth)
+            n = (numberOfScreens + 1) * screenWidth;
+        
+        int r = n % barLength;
+        if (r != 0)
+            n = n - r + barLength;
+        
+        resize(n);
+    }
+    
     public StaffNoteLine getLine(int i) throws IndexOutOfBoundsException {
         return theLines.get(i);
     }

--- a/src/smp/components/staff/sequences/StaffSequence.java
+++ b/src/smp/components/staff/sequences/StaffSequence.java
@@ -49,6 +49,20 @@ public class StaffSequence implements Serializable {
     }
     
     /**
+     * <p>Add empty lines to set the length of the sequence.</p>
+     * 
+     * <p>Without effect if the length is already greater or equal.</p>
+     * 
+     * @param n the desired length
+     */
+    public void resize(int n) {
+        int currentSize = theLines.size();
+        for (int i = 0; i < n - currentSize; i++) {
+            theLines.add(new StaffNoteLine());
+        }   
+    }
+    
+    /**
      * <p>Compute the index of the line marking the end of this sequence,
      * <i>i.e.</i> the first line that should <b>not</b> be played.</p>
      * 
@@ -77,12 +91,8 @@ public class StaffSequence implements Serializable {
         try {
             return theLines.get(i);
         } catch (IndexOutOfBoundsException e) {
-            theLines.add(new StaffNoteLine());
-            try {
-                return theLines.get(i);
-            } catch (IndexOutOfBoundsException e2) {
-                return getLine(i);
-            }
+            resize(i + 1);
+            return getLine(i);
         }
     }
 

--- a/src/smp/components/staff/sequences/mpc/MPCDecoder.java
+++ b/src/smp/components/staff/sequences/mpc/MPCDecoder.java
@@ -89,7 +89,6 @@ public class MPCDecoder {
     private static StaffSequence populateSequence(String timeSig,
             ArrayList<String> songData, String tempo) {
         StaffSequence song = new StaffSequence();
-        song.getTheLines().clear();
         song.setTempo(Double.parseDouble(tempo));
         int accum = 0;
         for (String s : songData) {
@@ -129,9 +128,7 @@ public class MPCDecoder {
             sl.setVolume(vol);
             song.addLine(sl);
         }
-        while (song.getTheLines().size() < Values.LINES_PER_MPC_SONG) {
-            song.getTheLines().add(new StaffNoteLine());
-        }
+        song.resize(Values.LINES_PER_MPC_SONG);
         return song;
     }
 

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -2,6 +2,7 @@ package smp.fx;
 
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
@@ -358,6 +359,27 @@ public class SMPFXController {
                 StateMachine.getCurrentLineProperty());
         
         scrollbar.disableProperty().bind(StateMachine.getPlaybackActiveProperty());
+        
+        // Setup playbars visibility
+        StateMachine.getPlaybackPositionProperty().addListener((obv, oldv, newv) -> {
+            if (!StateMachine.isPlaybackActive()) {
+                return;
+            }
+            staffPlayBars.getChildren().get((int) oldv).setVisible(false);
+            staffPlayBars.getChildren().get((int) newv).setVisible(true);
+        });
+        
+        StateMachine.getPlaybackActiveProperty().addListener(obv -> {
+            if (!StateMachine.isPlaybackActive()) {
+                for (Node n : staffPlayBars.getChildren()) {
+                    n.setVisible(false);
+                }
+                
+            } else {
+                int pos = StateMachine.getPlaybackPosition();
+                staffPlayBars.getChildren().get(pos).setVisible(true);
+            }
+        });
         
     }
     /**

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -361,6 +361,15 @@ public class SMPFXController {
         
         scrollbar.disableProperty().bind(StateMachine.getPlaybackActiveProperty());
         
+        // Trigger redraw when the position changes, editing mode only
+        StateMachine.getCurrentLineProperty().addListener(obs -> {
+            int idx = StateMachine.getMeasureLineNum();
+            Platform.runLater(() -> {
+                staff.redraw();
+                staff.getStaffImages().updateStaffMeasureLines(idx);
+            });
+        });
+        
         // Setup playbars visibility
         StateMachine.getPlaybackPositionProperty().addListener((obv, oldv, newv) -> {
             if (!StateMachine.isPlaybackActive()) {

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -472,11 +472,6 @@ public class SMPFXController {
         return controlPanel;
     }
 
-    /** @return The slider that controls the tempo in the control panel. */
-    public Slider getTempoSlider() {
-        return controlPanel.getScrollbar();
-    }
-
     /** @return The tempo plus button. */
     public ImageView getTempoPlus() {
         return tempoPlus;

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -335,6 +335,18 @@ public class SMPFXController {
         // Fix TextField focus problems.
         new SongNameController(songName, this);
         
+        // Bind playback active property
+        StateMachine.getPlaybackActiveProperty().bind(Bindings.createBooleanBinding(
+                () -> {
+                    switch (StateMachine.getState()) {
+                    case SONG_PLAYING:
+                    case ARR_PLAYING:
+                        return true;
+                    default:
+                        return false;
+                    }
+                }, StateMachine.getStateProperty()));
+        
         // Bind displayed tempo to internal value in state machine
         tempoIndicator.textProperty().bindBidirectional(StateMachine.getTempoProperty(), new NumberStringConverter());
         

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -357,6 +357,8 @@ public class SMPFXController {
         scrollbar.valueProperty().bindBidirectional(
                 StateMachine.getCurrentLineProperty());
         
+        scrollbar.disableProperty().bind(StateMachine.getPlaybackActiveProperty());
+        
     }
     /**
      * @return The <code>HBox</code> that holds the staff measure lines.

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -1,5 +1,6 @@
 package smp.fx;
 
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -379,6 +380,20 @@ public class SMPFXController {
                 int pos = StateMachine.getPlaybackPosition();
                 staffPlayBars.getChildren().get(pos).setVisible(true);
             }
+        });
+        
+        // Setup arrangement listview
+        StateMachine.getArrangementSongIndexProperty().addListener(obv -> {
+            int idx = StateMachine.getArrangementSongIndex();
+            arrangementList.getSelectionModel().select(idx);
+            if (idx != -1)
+                Platform.runLater(() -> arrangementList.scrollTo(idx));
+            staff.setSequenceName(arrangementList.getSelectionModel().getSelectedItem());
+        });
+        
+        StateMachine.getPlaybackActiveProperty().addListener(obv -> {
+            if (!StateMachine.isPlaybackActive())
+                StateMachine.setArrangementSongIndex(-1);
         });
         
     }

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -390,13 +390,6 @@ public class SMPFXController {
     }
 
     /**
-     * @return The <code>HBox</code> that holds the staff play bars.
-     */
-    public HBox getStaffPlayBars() {
-        return staffPlayBars;
-    }
-
-    /**
      * @return The <code>HBox</code> that holds the staff measure numbers.
      */
     public HBox getStaffMeasureNums() {

--- a/src/smp/fx/SMPFXController.java
+++ b/src/smp/fx/SMPFXController.java
@@ -1,5 +1,6 @@
 package smp.fx;
 
+import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Slider;
@@ -14,6 +15,7 @@ import smp.ImageIndex;
 import smp.ImageLoader;
 import smp.SoundfontLoader;
 import smp.commandmanager.ModifySongManager;
+import smp.components.Values;
 import smp.components.controls.Controls;
 import smp.components.staff.Staff;
 import smp.components.staff.StaffInstrumentEventHandler;
@@ -335,6 +337,13 @@ public class SMPFXController {
         
         // Bind displayed tempo to internal value in state machine
         tempoIndicator.textProperty().bindBidirectional(StateMachine.getTempoProperty(), new NumberStringConverter());
+        
+        // Setup scrollbar
+        scrollbar.maxProperty().bind(Bindings.createIntegerBinding(
+                () -> StateMachine.getMaxLine() - Values.NOTELINES_IN_THE_WINDOW,
+                StateMachine.getMaxLineProperty()));
+        scrollbar.valueProperty().bindBidirectional(
+                StateMachine.getCurrentLineProperty());
         
     }
     /**

--- a/src/smp/presenters/api/load/Utilities.java
+++ b/src/smp/presenters/api/load/Utilities.java
@@ -447,10 +447,10 @@ public class Utilities {
         theStaff.setSequenceFile(inputFile);
 //        StateMachine.setTempo(loaded.getTempo());
 //        theStaff.updateCurrTempo();
-        theStaff.getControlPanel()
-                .getScrollbar()
-                .setMax(loaded.getTheLines().size()
-                        - Values.NOTELINES_IN_THE_WINDOW);
+//        theStaff.getControlPanel()
+//                .getScrollbar()
+//                .setMax(loaded.getTheLines().size()
+//                        - Values.NOTELINES_IN_THE_WINDOW);
         theStaff.setLocation(0);
         theStaff.getNoteMatrix().redraw();
         String fname = inputFile.getName();

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -90,6 +90,11 @@ public class StateMachine {
      * Technically this is the first line that cannot be displayed.
      */
     private static IntegerProperty maxLine = new SimpleIntegerProperty(Values.DEFAULT_LINES_PER_SONG);
+    
+    /**
+     * Currently selected song in arranger mode
+     */
+    private static IntegerProperty arrangementSongIndex = new SimpleIntegerProperty(-1);
 
     /**
      * This is the current tempo that the program is running at.
@@ -241,6 +246,18 @@ public class StateMachine {
     
     public static void setMaxLine(int num) {
         maxLine.set(num);
+    }
+    
+    public static IntegerProperty getArrangementSongIndexProperty() {
+        return arrangementSongIndex;
+    }
+    
+    public static int getArrangementSongIndex() {
+        return arrangementSongIndex.get();
+    }
+    
+    public static void setArrangementSongIndex(int i) {
+        arrangementSongIndex.set(i);
     }
 
     /** Sets that the song is now loop-enabled. */

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -68,6 +68,11 @@ public class StateMachine {
     private static ObjectProperty<ProgramState> currentState = new SimpleObjectProperty<>(ProgramState.EDITING);
     
     private static BooleanProperty playbackActive = new SimpleBooleanProperty(false);
+    
+    /**
+     * Index of the current position on the screen during playback
+     */
+    private static IntegerProperty playbackPosition = new SimpleIntegerProperty(0);
 
     /**
      * The default time signature that we start out with is 4/4 time.
@@ -142,6 +147,18 @@ public class StateMachine {
 
     public static boolean isPlaybackActive() {
         return playbackActive.get();
+    }
+    
+    public static IntegerProperty getPlaybackPositionProperty() {
+        return playbackPosition;
+    }
+    
+    public static int getPlaybackPosition() {
+        return playbackPosition.get();
+    }
+    
+    public static void setPlaybackPosition(int n) {
+        playbackPosition.set(n);
     }
 
     /**

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -6,7 +6,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.input.KeyCode;
 import smp.components.Values;
 
@@ -70,7 +72,13 @@ public class StateMachine {
      * The current measure line number that the program is on. Typically a
      * number between 0 and 383. This is zero by default.
      */
-    private static int currentLine = 0;
+    private static IntegerProperty currentLine = new SimpleIntegerProperty(0);
+    
+    /**
+     * The furthest you can reach by scrolling to the end of the sequence.
+     * Technically this is the first line that cannot be displayed.
+     */
+    private static IntegerProperty maxLine = new SimpleIntegerProperty(Values.DEFAULT_LINES_PER_SONG);
 
     /**
      * This is the current tempo that the program is running at.
@@ -161,6 +169,10 @@ public class StateMachine {
     public static void setTempo(double num) {
         tempo.set(num);
     }
+    
+    public static IntegerProperty getCurrentLineProperty() {
+        return currentLine;
+    }
 
     /**
      * Gets the current line number that we're on. Typically a value between 0
@@ -170,7 +182,7 @@ public class StateMachine {
      * @return The current line number (left justify)
      */
     public static int getMeasureLineNum() {
-        return currentLine;
+        return currentLine.get();
     }
 
     /**
@@ -181,7 +193,19 @@ public class StateMachine {
      *            to.
      */
     public static void setMeasureLineNum(int num) {
-        currentLine = num;
+        currentLine.set(num);
+    }
+    
+    public static IntegerProperty getMaxLineProperty() {
+        return maxLine;
+    }
+    
+    public static int getMaxLine() {
+        return maxLine.get();
+    }
+    
+    public static void setMaxLine(int num) {
+        maxLine.set(num);
     }
 
     /** Sets that the song is now loop-enabled. */

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -7,8 +7,10 @@ import java.util.Set;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.input.KeyCode;
 import smp.components.Values;
 
@@ -61,7 +63,7 @@ public class StateMachine {
      * The default state that the program is in is the EDITING state, in which
      * notes are being placed on the staff.
      */
-    private static ProgramState currentState = ProgramState.EDITING;
+    private static ObjectProperty<ProgramState> currentState = new SimpleObjectProperty<>(ProgramState.EDITING);
 
     /**
      * The default time signature that we start out with is 4/4 time.
@@ -101,6 +103,10 @@ public class StateMachine {
      */
     private StateMachine() {
     }
+    
+    public static ObjectProperty<ProgramState> getStateProperty() {
+        return currentState;
+    }
 
     /**
      * Get the current <code>State</code> of the <code>StateMachine</code>
@@ -108,7 +114,7 @@ public class StateMachine {
      * @return The current <code>State</code>.
      */
     public static ProgramState getState() {
-        return currentState;
+        return currentState.get();
     }
 
     /**
@@ -116,14 +122,14 @@ public class StateMachine {
      *            Set the <code>StateMachine</code> to a certain State.
      */
     public static void setState(ProgramState s) {
-        currentState = s;
+        currentState.set(s);
     }
 
     /**
      * Sets the state back to "Editing" by default.
      */
     public static void resetState() {
-        currentState = ProgramState.EDITING;
+        currentState.set(ProgramState.EDITING);
     }
 
     /**

--- a/src/smp/stateMachine/StateMachine.java
+++ b/src/smp/stateMachine/StateMachine.java
@@ -5,9 +5,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -64,6 +66,8 @@ public class StateMachine {
      * notes are being placed on the staff.
      */
     private static ObjectProperty<ProgramState> currentState = new SimpleObjectProperty<>(ProgramState.EDITING);
+    
+    private static BooleanProperty playbackActive = new SimpleBooleanProperty(false);
 
     /**
      * The default time signature that we start out with is 4/4 time.
@@ -130,6 +134,14 @@ public class StateMachine {
      */
     public static void resetState() {
         currentState.set(ProgramState.EDITING);
+    }
+    
+    public static BooleanProperty getPlaybackActiveProperty() {
+        return playbackActive;
+    }
+
+    public static boolean isPlaybackActive() {
+        return playbackActive.get();
     }
 
     /**


### PR DESCRIPTION
Some light structural changes to address the infamous freeze issue and close #71.

The first part of this wave of commits moves code into StaffSequence so that the implementation of that class can be hidden. A sequence can be resized or normalized, which is a form of smart resizing to make updating the screen easier while a song is running. This fixes some edge case where the code calculating how to advance the screen would somehow result in a IndexOutOfBoundsException, triggering a freeze before switching to the next song.

The rest of the commits add various observable properties so that the GUI can update itself through listeners. The code running the animation no longer sends jobs to the FXAT to update the scrollbar, the highlight playbar, or the arrangement song list. Many freezes used to occur as a result of one of these jobs failing silently. The loop that used to wait for these jobs to succeed has been removed, so now no freezes can happen right after switching to the next song in an arrangement.

Additionally, scrolling through the current sequence is now impossible while a song is running.