### PR TITLE
Centralize version string in Gradle properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,14 @@ sourceSets {
     }
 }
 
+tasks.processResources {
+    val projectVersion = project.version
+    inputs.property("version", projectVersion)
+    filesMatching("gradle.bridge.properties") {
+        expand("projectVersion" to projectVersion)
+    }
+}
+
 application {
     // Define the main class for the application.
     mainClass = "gui.SuperMarioPaint"

--- a/src/gui/Settings.java
+++ b/src/gui/Settings.java
@@ -7,6 +7,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import gui.resources.SMPResourceUtil;
+
 /**
  * A loadable settings file that determines whatever is supposed
  * to display eventually on the screen.
@@ -16,7 +18,7 @@ import java.io.Serializable;
 public class Settings {
 
     /** The current version number of this program. */
-    public final static String version = "v1.5.1";
+    public final static String version = "v%s".formatted(SMPResourceUtil.getProperty("gradle.bridge.properties", "version"));
 
     /** The name of the file that we write to. */
     private final static String settingsFile = "settings.data";

--- a/src/gui/resources/SMPResourceUtil.java
+++ b/src/gui/resources/SMPResourceUtil.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Properties;
 
 /**
  * <p>This class contains static methods to access <i>Super Mario Paint</i>
@@ -94,6 +95,27 @@ public class SMPResourceUtil {
             throw new NullPointerException("Cannot load resource: " + name);
         
         return inStream;
+    }
+    
+    /**
+	 * <p>Get a resource properties string stored as an internal file
+	 * (packaged with the distribution).
+	 * @param propsFileName Name of the properties file to get information from
+	 * @param propName Name of the property to retrieve
+	 * @return The property value, or <b>null</b> if the resource cannot be read
+	 */
+    public static String getProperty(String propsFileName, String propName) {
+    	String valueRead;
+    	
+    	try {
+    		Properties props = new Properties();
+    		props.load(SMPResourceUtil.getStream(propsFileName));
+    		valueRead = props.getProperty(propName);
+    	} catch (IOException | NullPointerException e) {
+    		valueRead = null;
+    	}
+    	
+    	return valueRead;
     }
     
     /**

--- a/src/resources/gradle.bridge.properties
+++ b/src/resources/gradle.bridge.properties
@@ -1,0 +1,1 @@
+version=${projectVersion}


### PR DESCRIPTION
This is a rather short PR that will ease resolution of #66 later.

* It creates a properties file in the resources folder, which is accessible by Java code using `ClassLoader.getResourceAsStream`.
* The properties file contains a placeholder that is later filled by Gradle during a build/run, using the `project.version` value from `gradle.properties` (Java code cannot read `gradle.properties` directly).
* A new method is created in `SMPResourceUtil` that reads a property value from a given property files name, which is used in `Settings` to populate the title bar version string.