### PR TITLE
chore: omit indentation and line-ending commits from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# chore(format): replace indentation tabs with spaces
+1257f7032c1b4d4ec832a0a89547ce09dae5d8e7
+
+# chore(format): uniformize usage of unix line endings
+cb2afd5a9e741a02751bf3eab538cee2d80ab49a
+


### PR DESCRIPTION
This tiny PR allows for omitting the following commits while using `git blame`:

* 1257f7032c1b4d4ec832a0a89547ce09dae5d8e7
* cb2afd5a9e741a02751bf3eab538cee2d80ab49a

This allows for easier identification of people that adds features, without refactors that don't change code getting in the way. 👍🏻 