### PR TITLE
Reduce complexity of big methods

### DIFF
--- a/src/backend/BackendUtils.java
+++ b/src/backend/BackendUtils.java
@@ -1,0 +1,21 @@
+package backend;
+
+public class BackendUtils {
+
+	private BackendUtils() {}
+	
+	/**
+	 * Given an instrument index, retrieves it possibly swapped, if and
+	 * only if the input corresponds to the entries of the piranha
+	 * and the coin (if one is given, it returns the other).
+	 * 
+	 * @param instId The instrument index to swap
+	 * @return The instrument index, possibly swapped
+	 */
+	public static int swapCoinPiranhaInstrumentIdxs(int instId) {
+		if (instId == 15) return 16;
+		if (instId == 16) return 15;
+		return instId;
+	}
+	
+}

--- a/src/backend/saving/mpc/MPCDecoder.java
+++ b/src/backend/saving/mpc/MPCDecoder.java
@@ -1,12 +1,5 @@
 package backend.saving.mpc;
 
-import static backend.saving.mpc.TextUtil.chop;
-import static backend.saving.mpc.TextUtil.clean;
-import static backend.saving.mpc.TextUtil.dice;
-import static backend.saving.mpc.TextUtil.parseAccidental;
-import static backend.saving.mpc.TextUtil.parsePosition;
-import static backend.saving.mpc.TextUtil.parseVolume;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -82,66 +75,84 @@ public class MPCDecoder implements Decoder<Song> {
         if (in == null || in.isEmpty() || in.indexOf('*') == -1) {
             throw new ParseException("Invalid Text File.", 0);
         }
-        List<String> everything = chop(clean(in));
+        List<String> everything = TextUtil.chop(TextUtil.clean(in));
         String timeSig = in.substring(0, in.indexOf('*'));
         String tempo = in.substring(in.indexOf('%') + 1);
         return populateSequence(timeSig, everything, tempo);
     }
 
     /**
-     * Creates a new Super Mario Paint sequence from the input Mario Paint
-     * Composer text data.
+     * Parses the notes of a processed note line given its instruments.
+     * 
+     * @param sl The note line to deposit the parsing results into
+     * @param inst The list of instruments
+     */
+    private void parseNotes(NoteLine sl, List<String> inst) {
+    	for (String note : inst) {
+            if (note.isEmpty())
+                continue;
+            
+            SMPInstrument in = MPCInstrumentIndex.valueOf(note.charAt(0));
+            int pos = 0;
+            Accidental acc = Accidental.NATURAL;
+            MuteModifier mod = MuteModifier.REGULAR;
+            
+            if (note.length() == 3) {
+                if (note.substring(1).equals("17")) {
+                	mod = MuteModifier.MUTE_THIS_INST;
+                } else {
+                    pos = TextUtil.parsePosition(note.charAt(1));
+                    acc = TextUtil.parseAccidental(note.charAt(2));
+                }
+            } else if (note.length() == 2) {
+                pos = TextUtil.parsePosition(note.charAt(1));
+            }
+            
+            Note sn = new Note(in, pos, acc, mod);
+            sl.getNotes().add(sn);
+        }
+    }
+    
+    /**
+     * Creates a new Super Mario Paint song from the
+     * Mario Paint Composer text data input.
      *
      * @param timeSig
      *            The time signature of the Mario Paint Composer song.
      * @param songData
-     *            The text data of the Mario Paint Composer song. This defines
-     *            the notes and instruments on each note line.
+     *            The text data of the Mario Paint Composer song.
+     *            This defines the notes and instruments on each note line.
      * @param tempo
      *            The tempo at which this should be played at.
-     * @return A new <code>StaffSequence</code> that is to be loaded by the main
+     * @return A new <code>Song</code> that is to be loaded by the main
      *         program.
      */
-    private Song populateSequence(String timeSig,
-            List<String> songData, String tempo) {
+    private Song populateSequence(String timeSig, List<String> songData, String tempo) {
+    	
         List<NoteLine> lines = new ArrayList<>(Values.LINES_PER_MPC_SONG);
 
         for (String s : songData) {
             NoteLine sl = new NoteLine();
             if (s.length() <= 1) {
-                lines.addLast(sl);
+                lines.add(sl);
                 continue;
             }
-            List<String> inst = dice(s);
-            int vol = parseVolume(s.charAt(s.length() - 2));
-            for (String note : inst) {
-                if (note.isEmpty())
-                    continue;
-                SMPInstrument in = MPCInstrumentIndex.valueOf(note.charAt(0));
-                int pos = 0;
-                Accidental acc = Accidental.NATURAL;
-                if (note.length() == 3) {
-                    if (note.substring(1).equals("17")) {
-                        Note mn = new Note(in, pos, acc, MuteModifier.MUTE_THIS_INST);
-                        sl.getNotes().add(mn);
-                        continue;
-                    } else {
-                        pos = parsePosition(note.charAt(1));
-                        acc = parseAccidental(note.charAt(2));
-                    }
-                } else if (note.length() == 2) {
-                    pos = parsePosition(note.charAt(1));
-                    acc = Accidental.NATURAL;
-                }
-                Note sn = new Note(in, pos, acc);
-                sl.getNotes().add(sn);
-            }
+
+            List<String> inst = TextUtil.dice(s);
+            int vol = TextUtil.parseVolume(s.charAt(s.length() - 2));
+            
+            parseNotes(sl, inst);
+            
             sl.setVolume(vol);
-            lines.addLast(sl);
+            lines.add(sl);
         }
 
         Song song = new Song(lines);
         song.setTempo(Double.parseDouble(tempo));
+        
+        // TODO: Check if this is valid for MPC files.
+        // song.setTimeSignature(TimeSignature.valueOf(timeSig));
+        
         return song;
     }
 

--- a/src/backend/saving/smp/SMPDecoder.java
+++ b/src/backend/saving/smp/SMPDecoder.java
@@ -14,10 +14,12 @@ import backend.songs.MuteModifier;
 import backend.songs.Note;
 import backend.songs.NoteLine;
 import backend.songs.Song;
+import backend.songs.SongProperties;
 import backend.songs.TimeSignature;
 import gui.SMPInstrument;
 import gui.Utilities;
 import gui.Values;
+import utilities.CollectionUtils;
 
 public class SMPDecoder implements Decoder<Song> {
 
@@ -47,92 +49,91 @@ public class SMPDecoder implements Decoder<Song> {
     }
 
     /**
-     * Parses a bunch of text from a save file and makes a
-     * <code>StaffSequence</code> out of it.
-     *
-     * @param read
-     *            <code>ArrayList</code> of notes and parameters.
-     * @return Hopefully, a decoded <code>StaffSequence</code>
+     * Initializes a {@link SongProperties} with the values read from the save file.
+     * 
+     * @param props The {@link SongProperties} to initialize
+     * @param sp The list of parameters
      */
-    private Song parseText(List<String> read) {
-        List<NoteLine> lines = new ArrayList<>();
-        double tempo = Values.DEFAULT_TEMPO;
-        boolean[] noteExtensions = new boolean[Values.NUM_INSTRUMENTS];
-        TimeSignature timeSignature = Values.DEFAULT_TIME_SIGNATURE;
-        String soundset = Values.DEFAULT_SOUNDFONT;
-        
-        for (String s : read) {
-            if (s.contains("TEMPO") || s.contains("EXT") || s.contains("TIME") || s.contains("SOUNDSET")) {
-                String[] sp = s.split(",");
-                for (String spl : sp) {
-                    String num = spl.substring(spl.indexOf(":") + 1);
-                    if (spl.contains("TEMPO")) {
-                        tempo = Double.parseDouble(num.trim());
-                    } else if (spl.contains("EXT")) {
-                        noteExtensions = Utilities.boolFromLong(Long
-                                .parseLong(num.trim()));
-                        swap15And16(noteExtensions);
-                    } else if (spl.contains("TIME")) {
-                        timeSignature = TimeSignature.valueOf(num.trim());
-                    } else if (spl.contains("SOUNDSET")) {
-                        soundset = num.trim();
-                    }
+    private void initializeSongProperties(SongProperties props, String[] sp) {
+        for (String spl : sp) {
+            String num = spl.substring(spl.indexOf(":") + 1);
+            if (spl.contains("TEMPO")) {
+                props.setTempo(
+                        Double.parseDouble(num.trim()));
+            } else if (spl.contains("EXT")) {
+                // Coin and piranha used to be swapped, so we unswap the note extensions
+                // found in sequences files to conform with existing files
+                props.setNoteExtensions(
+                        Utilities.boolFromLong(Long.parseLong(num.trim())),
+                        exts -> CollectionUtils.swapItems(exts, 15, 16));
+            } else if (spl.contains("TIME")) {
+                props.setTimeSignature(
+                        TimeSignature.valueOf(num.trim()));
+            } else if (spl.contains("SOUNDSET")) {
+                props.setSoundset(
+                        num.trim());
+            }
+        }
+    }
+    
+    /**
+     * Initializes the lines of a {@link Song}.
+     * 
+     * @param lines The lines container to be initialized.
+     * @param sp The list of parameters
+     * @param timeSignature The time signature to use.
+     */
+    private void initializeSongLines(List<NoteLine> lines, String[] sp, TimeSignature timeSignature) {
+        int lineNum = 0;
+        NoteLine st = new NoteLine();
+        for (String spl : sp) {
+            if (spl.contains(":") && !spl.contains("VOL")) {
+                String[] meas = spl.split(":");
+                if (meas.length != 2) {
+                    continue;
                 }
-            } else {
-                String[] sp = s.split(",");
-                int lineNum = 0;
-                NoteLine st = new NoteLine();
-                for (String spl : sp) {
-                    if (spl.contains(":") && !spl.contains("VOL")) {
-                        String[] meas = spl.split(":");
-                        if (meas.length != 2) {
-                            continue;
-                        }
-                        lineNum = (Integer.parseInt(meas[0]) - 1)
-                                * timeSignature.top()
-                                + Integer.parseInt(meas[1]);
-                    } else {
-                        if (spl.contains("VOL")) {
-                            st.setVolume(Integer.parseInt(spl.substring(
-                                    spl.indexOf(":") + 1).trim()));
-                        } else {
-                            try {
-                                st.getNotes().add(parseNote(spl));
-                            } catch (ParseException e) {
-                                e.printStackTrace();
-                            }
-                        }
-                    }
-                }
+                lineNum = (Integer.parseInt(meas[0]) - 1)
+                        * timeSignature.top()
+                        + Integer.parseInt(meas[1]);
                 
-                if (lineNum < lines.size()) {
-                    lines.set(lineNum, st);
-                    
-                } else {
-                    while (lines.size() < lineNum) {
-                        lines.addLast(new NoteLine());
-                    }
-                    
-                    lines.addLast(st);
+            } else if (spl.contains("VOL")) {
+                st.setVolume(Integer.parseInt(spl.substring(
+                        spl.indexOf(":") + 1).trim()));
+            } else {
+                try {
+                    st.getNotes().add(parseNote(spl));
+                } catch (ParseException e) {
+                    e.printStackTrace();
                 }
             }
         }
-
-        Song loaded = new Song(lines);
-        loaded.setTempo(tempo);
-        loaded.setNoteExtensions(noteExtensions);
-        loaded.setTimeSignature(timeSignature);
-        loaded.setSoundset(soundset);
         
-        return loaded;
+        CollectionUtils.addFillerThenElement(lines, st, lineNum, NoteLine::new);
     }
     
-    // Coin and piranha used to be swapped, so we unswap the note extensions
-    // found in sequences files to conform with existing files
-    private void swap15And16(boolean[] exts) {
-        boolean ext15 = exts[15];
-        exts[15] = exts[16];
-        exts[16] = ext15;
+    /**
+     * Parses a bunch of text from a save file and makes a
+     * <code>Song</code> out of it.
+     *
+     * @param read
+     *            <code>List</code> of notes and parameters.
+     * @return Hopefully, a decoded <code>Song</code>
+     */
+    private Song parseText(List<String> read) {
+        List<NoteLine> lines = new ArrayList<>();
+        SongProperties songProps = new SMPSongProperties();
+        
+        for (String s : read) {
+            String[] sp = s.split(",");
+            
+            if (CollectionUtils.containsAny(s, "TEMPO", "EXT", "TIME", "SOUNDSET")) {
+                initializeSongProperties(songProps, sp);
+            } else {
+                initializeSongLines(lines, sp, songProps.getTimeSignature());
+            }
+        }
+
+        return new Song(lines, songProps);
     }
 
     private static Note parseNote(String spl) throws ParseException {

--- a/src/backend/saving/smp/SMPSongProperties.java
+++ b/src/backend/saving/smp/SMPSongProperties.java
@@ -1,0 +1,64 @@
+package backend.saving.smp;
+
+import java.util.function.Consumer;
+
+import backend.songs.SongProperties;
+import backend.songs.TimeSignature;
+import gui.Values;
+
+public class SMPSongProperties implements SongProperties {
+
+    private double tempo = Values.DEFAULT_TEMPO;
+    private boolean[] noteExtensions = new boolean[Values.NUM_INSTRUMENTS];
+    private TimeSignature timeSignature = Values.DEFAULT_TIME_SIGNATURE;
+    private String soundset = Values.DEFAULT_SOUNDFONT;
+    
+    @Override
+    public double getTempo() {
+        return tempo;
+    }
+    
+    @Override
+    public void setTempo(double tempo) {
+        this.tempo = tempo;
+    }
+    
+    @Override
+    public boolean[] getNoteExtensions() {
+        return noteExtensions;
+    }
+    
+    @Override
+    public void setNoteExtensions(boolean[] noteExtensions) {
+        setNoteExtensions(noteExtensions, null);
+    }
+    
+    @Override
+    public void setNoteExtensions(boolean[] noteExtensions, Consumer<boolean[]> fnOnNoteExtensionsSet) {
+        this.noteExtensions = noteExtensions;
+        
+        if (fnOnNoteExtensionsSet != null)
+            fnOnNoteExtensionsSet.accept(noteExtensions);
+    }
+    
+    @Override
+    public TimeSignature getTimeSignature() {
+        return timeSignature;
+    }
+    
+    @Override
+    public void setTimeSignature(TimeSignature timeSignature) {
+        this.timeSignature = timeSignature;
+    }
+    
+    @Override
+    public String getSoundset() {
+        return soundset;
+    }
+    
+    @Override
+    public void setSoundset(String soundset) {
+        this.soundset = soundset;
+    }
+    
+}

--- a/src/backend/songs/MuteModifier.java
+++ b/src/backend/songs/MuteModifier.java
@@ -21,4 +21,29 @@ public enum MuteModifier {
      */
     MUTE_THIS_INST;
 
+	/**
+	 * Retrieves the {@link MuteModifier} that corresponds to the
+	 * given mute instrument/pitch flags.
+	 * 
+	 * <p>Specifically:
+	 * 
+	 * <ul>
+	 * <li>If {@code muteInstrument} is true, regardless of the value of
+	 *     {@code mutePitch}, it returns {@link MUTE_THIS_INST}.</li>
+	 * <li>If {@code muteInstrument} is false and {@code mutePitch} is true,
+	 *     it returns {@link MUTE_THIS_PITCH}.</li>
+	 * <li>If both {@code muteInstrument} and {@code mutePitch} are false,
+	 *     it returns {@link GENERAL}.</li>
+	 * </ul>
+	 * 
+	 * @param muteInstrument Whether the instrument should be muted at every pitch
+	 * @param mutePitch Whether the instrument should be muted at the specific pitch
+	 * @return A {@link MuteModifier} that corresponds to the selection
+	 */
+	public static MuteModifier givenFlags(boolean muteInstrument, boolean mutePitch) {
+		if (muteInstrument) return MUTE_THIS_INST;
+		if (mutePitch) return MUTE_THIS_PITCH;
+		return REGULAR;
+	}
+	
 }

--- a/src/backend/songs/Song.java
+++ b/src/backend/songs/Song.java
@@ -70,6 +70,16 @@ public class Song extends Sequence {
     }
     
     /**
+     * Builds a sequence with a list of note lines and a set of properties.
+     * @param lines A list of note lines
+     * @param props The properties to set to the song
+     */
+    public Song(List<NoteLine> lines, SongProperties props) {
+        this(lines);
+        setSongProperties(props);
+    }
+    
+    /**
      * Copy constructor for a song.
      * @param sequence A song to copy
      */
@@ -79,6 +89,13 @@ public class Song extends Sequence {
         System.arraycopy(sequence.noteExtensions, 0, this.noteExtensions, 0, this.noteExtensions.length);
     	this.timeSignature = sequence.timeSignature;
     	this.soundsetBinding = sequence.soundsetBinding;
+    }
+    
+    private void setSongProperties(SongProperties props) {
+        this.setTempo(props.getTempo());
+        this.setNoteExtensions(props.getNoteExtensions());
+        this.setTimeSignature(props.getTimeSignature());
+        this.setSoundset(props.getSoundset());
     }
 
     /**

--- a/src/backend/songs/SongProperties.java
+++ b/src/backend/songs/SongProperties.java
@@ -1,0 +1,20 @@
+package backend.songs;
+
+import java.util.function.Consumer;
+
+public interface SongProperties {
+
+    double getTempo();
+    void setTempo(double tempo);
+    
+    boolean[] getNoteExtensions();
+    void setNoteExtensions(boolean[] noteExtensions);
+    void setNoteExtensions(boolean[] noteExtensions, Consumer<boolean[]> fnOnNoteExtensionsSet);
+    
+    TimeSignature getTimeSignature();
+    void setTimeSignature(TimeSignature timeSignature);
+    
+    String getSoundset();
+    void setSoundset(String soundset);
+    
+}

--- a/src/backend/sound/NoteTracker.java
+++ b/src/backend/sound/NoteTracker.java
@@ -3,6 +3,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import backend.songs.Pitch;
+import backend.BackendUtils;
 import backend.songs.Note;
 import backend.songs.NoteLine;
 import gui.SMPInstrument;
@@ -56,10 +57,8 @@ class NoteTracker {
         boolean[] ext = StateMachine.getNoteExtensions();
 
         for (int i = 0; i < turnOff.length; i++) {
-            
-            @SuppressWarnings("java:S3358")
-            int j = (i == 15) ? 16 : (i == 16) ? 15 : i; // swap coin and piranha
-            
+        	int j = BackendUtils.swapCoinPiranhaInstrumentIdxs(i);
+        	
             if (turnOff[i] && isChannelOn(i) && !ext[j]) {
                 List<PlayingNote> pna = getNotesPlaying(i);
                 for (PlayingNote pn : pna)

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import javax.sound.midi.MidiChannel;
 
+import backend.BackendUtils;
 import backend.editing.ModifySongManager;
 import backend.saving.Decoder;
 import backend.songs.Accidental;
@@ -464,8 +465,7 @@ public class SMPFXController {
             boolean ex = StateMachine.getNoteExtension(inst.ordinal());
             StateMachine.setNoteExtension(inst.ordinal(), !ex);
             
-            @SuppressWarnings("java:S3358")
-            int i = (inst.ordinal() == 15) ? 16 : (inst.ordinal() == 16) ? 15 : inst.ordinal();
+            int i = BackendUtils.swapCoinPiranhaInstrumentIdxs(inst.ordinal());
             
             staff.getSequence().getNoteExtensions()[i] = !ex;
             

--- a/src/gui/clipboard/StaffClipboardAPI.java
+++ b/src/gui/clipboard/StaffClipboardAPI.java
@@ -128,12 +128,44 @@ public class StaffClipboardAPI {
     }
 
     /**
+     * Paste copied notes.
+     * 
+     * @param lineSrc The notes line to copy
+     * @param lineDest The notes line where the copy will be received
+     * @param line The line number
+     */
+    private void pasteNotes(NoteLine lineSrc, NoteLine lineDest, int line) {
+    	for (Note note : lineSrc.getNotes()) {
+            
+            // see StaffInstrumentEventHandler's placeNote function
+            Note theStaffNote = new Note(note);
+
+            if (lineDest.getNotes().isEmpty()) {
+                lineDest.setVolume(Values.DEFAULT_VELOCITY);
+                
+                if (line - StateMachine.getMeasureLineNum() < Values.NOTELINES_IN_THE_WINDOW) {
+                    StaffVolumeEventHandler sveh = theStaff.getDisplayManager()
+                            .getVolHandler(line - StateMachine.getMeasureLineNum());
+                    sveh.updateVolume();
+                }
+
+                commandManager.execute(new AddVolumeCommand(lineDest, Values.DEFAULT_VELOCITY));
+            }
+
+            if (!lineDest.getNotes().contains(theStaffNote)) {
+                lineDest.getNotes().add(theStaffNote);
+                StateMachine.setSongModified(true);
+                commandManager.execute(new AddNoteCommand(lineDest, theStaffNote));
+            }
+        }
+    }
+    
+    /**
      * Paste copied notes and volumes.
      * 
      * @param lineMoveTo starting line to paste data at
      */
     public void paste(int lineMoveTo) {
-
         Map<Integer, NoteLine> copiedData = theStaffClipboard.getCopiedData();
         
         for (Map.Entry<Integer, NoteLine> lineCopy : copiedData.entrySet()) {
@@ -141,32 +173,12 @@ public class StaffClipboardAPI {
             
             NoteLine lineDest = theStaff.getSequence().getLine(line);
             NoteLine lineSrc = lineCopy.getValue();
-            for(Note note : lineSrc.getNotes()) {
-                
-                // see StaffInstrumentEventHandler's placeNote function
-                Note theStaffNote = new Note(note);
-
-                if (lineDest.getNotes().isEmpty()) {
-                    lineDest.setVolume(Values.DEFAULT_VELOCITY);
-                    
-                    if (line - StateMachine.getMeasureLineNum() < Values.NOTELINES_IN_THE_WINDOW) {
-                        StaffVolumeEventHandler sveh = theStaff.getDisplayManager()
-                                .getVolHandler(line - StateMachine.getMeasureLineNum());
-                        sveh.updateVolume();
-                    }
-
-                    commandManager.execute(new AddVolumeCommand(lineDest, Values.DEFAULT_VELOCITY));
-                }
-
-                if (!lineDest.getNotes().contains(theStaffNote)) {
-                    lineDest.getNotes().add(theStaffNote);
-                    StateMachine.setSongModified(true);
-                    commandManager.execute(new AddNoteCommand(lineDest, theStaffNote));
-                }
-            }
             
-            // paste volume
-            if(!ignoreVolumesFlag) {
+            // Paste notes
+            pasteNotes(lineSrc, lineDest, line);
+            
+            // Paste volume
+            if (!ignoreVolumesFlag) {
                 commandManager.execute(new RemoveVolumeCommand(lineDest, lineDest.getVolume()));
                 lineDest.setVolume(lineSrc.getVolume());
                 commandManager.execute(new AddVolumeCommand(lineDest, lineDest.getVolume()));
@@ -176,8 +188,8 @@ public class StaffClipboardAPI {
                             .getVolHandler(line - StateMachine.getMeasureLineNum());
                     sveh.updateVolume();
                 }
-                StateMachine.setSongModified(true);
                 
+                StateMachine.setSongModified(true);
             }
             
         }

--- a/src/gui/components/staff/StaffMouseEventHandler.java
+++ b/src/gui/components/staff/StaffMouseEventHandler.java
@@ -190,8 +190,7 @@ public class StaffMouseEventHandler implements EventHandler<MouseEvent> {
         if ((Settings.debug & 0b10000) != 0)
             System.out.println("Index: " + theInd + "\nPosition: "+ position + "\nAcc: " + acc + "\nVel: " + vel);
         
-        @SuppressWarnings("java:S3358")
-        MuteModifier mod = muteA ? MuteModifier.MUTE_THIS_INST : mute ? MuteModifier.MUTE_THIS_PITCH : MuteModifier.REGULAR;
+        MuteModifier mod = MuteModifier.givenFlags(muteA, mute);
         
         Note theStaffNote = new Note(theInd, position, acc, mod);
         

--- a/src/utilities/CollectionUtils.java
+++ b/src/utilities/CollectionUtils.java
@@ -1,0 +1,57 @@
+package utilities;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class CollectionUtils {
+
+    private CollectionUtils() {}
+    
+    /**
+     * Determines if the given reference {@link String} contains
+     * any of the provided probes.
+     * 
+     * @param ref The reference to compare against
+     * @param probes One or more probe values to look for
+     * @return Whether at least one of the probes is contained in the reference
+     */
+    public static boolean containsAny(String ref, String... probes) {
+        return Arrays.asList(probes).stream().anyMatch(ref::contains);
+    }
+    
+    /**
+     * Swaps two items of a boolean array, in-place.
+     * 
+     * @param items The boolean array to process
+     * @param idx1 The first index to swap
+     * @param idx2 The second index to swap
+     */
+    public static void swapItems(boolean[] items, int idx1, int idx2) {
+        boolean tmp = items[idx1];
+        items[idx1] = items[idx2];
+        items[idx2] = tmp;
+    }
+    
+    /**
+     * Adds an element to a list at the specified index,
+     * after optionally adding filler to reach that index.
+     * 
+     * @param l The list to process
+     * @param elem The element to add
+     * @param idx The index at which the element is to be added
+     * @param fnGetFiller A generator function that provides filler if the index is the size of the list or greater
+     */
+    public static <T> void addFillerThenElement(List<T> l, T elem, int idx, Supplier<T> fnGetFiller) {
+        if (idx < l.size()) {
+            l.set(idx, elem);
+        } else {
+            while (l.size() < idx) {
+                l.add(fnGetFiller.get());
+            }
+            
+            l.add(elem);
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR deals with the reduction of Cognitive Complexity for some big methods. 👍🏻 

Cognitive Complexity is a benchmark included in SonarLint / SonarQube for IDE based on the number of `if`s and nested flow sequences (`while`, `for`, `try`/`catch`). By default, a Cognitive Complexity greater than 15 is flagged by the linter as a method with possibly too many responsibilities.

In critical cases where the number of lines of code and other parameters compound with cognitive complexity, the method then gets flagged as a "Brain Method", which is basically a method that does everything.

In this case, the following methods have been refactored so that their Cognitive Complexity is reduced within the allowed threshold:

| Class | Method | Notes |
| ----- | ----- | ----- |
| `SMPDecoder` | `parseText` | Flagged by the linter as a "Brain Method". |
| `StaffClipboardAPI` | `paste` | A separate method for pasting notes was extracted from here. |
| `MPCDecoder` | `populateSequence` | A separate method that parses notes was extracted. |

Additionally, methods `BackendUtils.swapCoinPiranhaInstrumentIdxs` and `MuteModifier.givenFlags` were created to encapsulate the complexities of swapping instrument indexes and selecting a mute modifier given a couple of flags.