### PR TITLE
Use getters/setters for mutable static values and complex structures

### DIFF
--- a/src/backend/saving/smp/SMPDecoder.java
+++ b/src/backend/saving/smp/SMPDecoder.java
@@ -150,8 +150,8 @@ public class SMPDecoder implements Decoder<Song> {
             throw new ParseException("Invalid note", 0);
         }
         theInstrument = SMPInstrument.valueOf(sp[0]);
-        for (int i = 0; i < Values.STAFF_NOTES.length; i++) {
-            if (sp[1].contains(Values.STAFF_NOTE_NAMES[i])) {
+        for (int i = 0; i < Values.getNotes().size(); i++) {
+            if (sp[1].contains(Values.getNotes().get(i).getName())) {
                 verticalPosition = i;
             }
         }

--- a/src/backend/songs/Note.java
+++ b/src/backend/songs/Note.java
@@ -123,7 +123,7 @@ public class Note {
      * @return The pitch of this note
      */
     public Pitch getPitch() {
-        return Pitch.valueOf(Values.STAFF_NOTES[verticalPosition].getValue() + accidental.getOffset());
+    	return Values.getNotePitch(verticalPosition, accidental.getOffset());
     }
 
     /**

--- a/src/backend/songs/NoteInfo.java
+++ b/src/backend/songs/NoteInfo.java
@@ -1,0 +1,25 @@
+package backend.songs;
+
+public class NoteInfo {
+
+	private int value;
+	private String name;
+	
+	private NoteInfo(int value, String name) {
+		this.value = value;
+		this.name = name;
+	}
+	
+	public static NoteInfo of(int value, String name) {
+		return new NoteInfo(value, name);
+	}
+	
+	public int getValue() {
+		return value;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+}

--- a/src/backend/songs/NoteLine.java
+++ b/src/backend/songs/NoteLine.java
@@ -33,7 +33,7 @@ public class NoteLine {
      * Create an empty line of notes at the default volume.
      */
     public NoteLine() {
-        this(Values.DEFAULT_VELOCITY);
+        this(Values.getDefaultVolume());
     }
     
     /**
@@ -43,7 +43,7 @@ public class NoteLine {
      */
     public NoteLine(int volume) {
         this.notes = new ArrayList<>();
-        this.volume = (checkVolumeValue(volume)) ? volume : Values.DEFAULT_VELOCITY;
+        this.volume = (checkVolumeValue(volume)) ? volume : Values.getDefaultVolume();
     }
     
     /**

--- a/src/gui/OptionsMenu.java
+++ b/src/gui/OptionsMenu.java
@@ -237,7 +237,7 @@ public class OptionsMenu {
         Slider dV = new Slider();
         dV.setMax((double) Values.MAX_VELOCITY + 1);
         dV.setMin(0);
-        dV.setValue(Values.DEFAULT_VELOCITY);
+        dV.setValue(Values.getDefaultVolume());
         dV.setShowTickMarks(true);
         dV.setShowTickLabels(true);
         dV.setSnapToTicks(true);
@@ -258,7 +258,7 @@ public class OptionsMenu {
     /** Updates the default volume of the program notes. */
     private void changeDefaultVol() {
         int vol = (int) defaultVolume.getValue();
-        Values.DEFAULT_VELOCITY = vol >= 128 ? 127 : vol;
+        Values.setDefaultVolume(vol >= 128 ? 127 : vol);
     }
 
     /** Updates the tempo from the options dialog. */

--- a/src/gui/OptionsMenu.java
+++ b/src/gui/OptionsMenu.java
@@ -372,12 +372,12 @@ public class OptionsMenu {
 
     private CheckBox makeBarsVisibleCheckbox() {
         CheckBox box = new CheckBox("Bars visible");
-        box.setSelected(Settings.barsVisible);
+        box.setSelected(Settings.areBarsVisible());
         return box;
     }
 
     private void updateBarVisibility() {
-        Settings.barsVisible = barsVisibleBox.isSelected();
+    	Settings.setBarsVisibility(barsVisibleBox.isSelected());
     }
 
     private CheckBox makeNumsVisibleCheckbox() {

--- a/src/gui/OptionsMenu.java
+++ b/src/gui/OptionsMenu.java
@@ -382,12 +382,12 @@ public class OptionsMenu {
 
     private CheckBox makeNumsVisibleCheckbox() {
         CheckBox box = new CheckBox("Measure numbers visible");
-        box.setSelected(Settings.numsVisible);
+        box.setSelected(Settings.areNumbersVisible());
         return box;
     }
 
     private void updateNumVisibility() {
-        Settings.numsVisible = numsVisibleBox.isSelected();
+    	Settings.setNumbersVisibility(numsVisibleBox.isSelected());
     }
 
 }

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -492,7 +492,7 @@ public class SMPFXController {
         } else {
             MidiChannel[] chan = soundPlayer.getChannels();
             if (chan[inst.getChannel() - 1] != null) {
-                chan[inst.getChannel() - 1].noteOn(Values.DEFAULT_NOTE, Values.DEFAULT_VELOCITY);
+                chan[inst.getChannel() - 1].noteOn(Values.DEFAULT_NOTE, Values.getDefaultVolume());
             }
             
             StateMachine.setSelectedInstrument(inst);

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -841,7 +841,7 @@ public class SMPFXController {
     
     private static String noteToString(Note note) {
         String instName = note.getInstrument().toString();
-        String noteName = Values.STAFF_NOTE_NAMES[note.getVerticalPosition()];
+        String noteName = Values.getNoteName(note.getVerticalPosition());
         String noteAcc = accidentalToString(note.getAccidental());
         String muteName = muteModifierToString(note.getMuteModifier());
         return instName + " " + noteName + noteAcc + muteName;

--- a/src/gui/Settings.java
+++ b/src/gui/Settings.java
@@ -100,6 +100,42 @@ public class Settings {
      */
     private static boolean numsVisible = true;
 
+    /**
+     * Checks whether vertical bars on the staff should be visible.
+     * 
+     * @return A flag denoting the current visibility setting.
+     */
+    public static boolean areBarsVisible() {
+    	return Settings.barsVisible;
+    }
+    
+    /**
+     * Sets whether vertical bars on the staff should be visible.
+     * 
+     * @param visibility The visibility flag setting to use.
+     */
+    public static void setBarsVisibility(boolean visibility) {
+    	Settings.barsVisible = visibility;
+    }
+    
+    /**
+     * Checks whether measure numbers on the staff should be visible.
+     * 
+     * @return A flag denoting the current visibility setting.
+     */
+    public static boolean areNumbersVisible() {
+    	return Settings.numsVisible;
+    }
+    
+    /**
+     * Sets whether measure numbers on the staff should be visible.
+     * 
+     * @param visibility The visibility flag setting to use.
+     */
+    public static void setNumbersVisibility(boolean visibility) {
+    	Settings.numsVisible = visibility;
+    }
+    
     /** Used to save settings via object serialization. */
     private static class SettingsSaver implements Serializable {
 
@@ -173,42 +209,6 @@ public class Settings {
             RESIZE_WIN       = loaded.set[9];
             ADV_MODE         = loaded.set[10];
         }
-    }
-    
-    /**
-     * Checks whether vertical bars on the staff should be visible.
-     * 
-     * @return A flag denoting the current visibility setting.
-     */
-    public static boolean areBarsVisible() {
-    	return Settings.barsVisible;
-    }
-    
-    /**
-     * Sets whether vertical bars on the staff should be visible.
-     * 
-     * @param visibility The visibility flag setting to use.
-     */
-    public static void setBarsVisibility(boolean visibility) {
-    	Settings.barsVisible = visibility;
-    }
-    
-    /**
-     * Checks whether measure numbers on the staff should be visible.
-     * 
-     * @return A flag denoting the current visibility setting.
-     */
-    public static boolean areNumbersVisible() {
-    	return Settings.numsVisible;
-    }
-    
-    /**
-     * Sets whether measure numbers on the staff should be visible.
-     * 
-     * @param visibility The visibility flag setting to use.
-     */
-    public static void setNumbersVisibility(boolean visibility) {
-    	Settings.numsVisible = visibility;
     }
 
 }

--- a/src/gui/Settings.java
+++ b/src/gui/Settings.java
@@ -93,7 +93,7 @@ public class Settings {
     /**
      * Visibility of the vertical bars on the staff
      */
-    public static boolean barsVisible = true;
+    private static boolean barsVisible = true;
     
     /**
      * Visibility of measure numbers on the staff
@@ -173,6 +173,24 @@ public class Settings {
             RESIZE_WIN       = loaded.set[9];
             ADV_MODE         = loaded.set[10];
         }
+    }
+    
+    /**
+     * Checks whether vertical bars on the staff should be visible.
+     * 
+     * @return A flag denoting the current visibility setting.
+     */
+    public static boolean areBarsVisible() {
+    	return Settings.barsVisible;
+    }
+    
+    /**
+     * Sets whether vertical bars on the staff should be visible.
+     * 
+     * @param visibility The visibility flag setting to use.
+     */
+    public static void setBarsVisibility(boolean visibility) {
+    	Settings.barsVisible = visibility;
     }
 
 }

--- a/src/gui/Settings.java
+++ b/src/gui/Settings.java
@@ -145,7 +145,7 @@ public class Settings {
         private static final long serialVersionUID = -3844082395768911493L;
 
         /** The number of setting types that we have. */
-        private final transient int NUM_SETTINGS = 11;
+        private static final transient int NUM_SETTINGS = 11;
 
         /** The array of settings that we are going to initialize. */
         public boolean[] set = new boolean[NUM_SETTINGS];

--- a/src/gui/Settings.java
+++ b/src/gui/Settings.java
@@ -98,7 +98,7 @@ public class Settings {
     /**
      * Visibility of measure numbers on the staff
      */
-    public static boolean numsVisible = true;
+    private static boolean numsVisible = true;
 
     /** Used to save settings via object serialization. */
     private static class SettingsSaver implements Serializable {
@@ -191,6 +191,24 @@ public class Settings {
      */
     public static void setBarsVisibility(boolean visibility) {
     	Settings.barsVisible = visibility;
+    }
+    
+    /**
+     * Checks whether measure numbers on the staff should be visible.
+     * 
+     * @return A flag denoting the current visibility setting.
+     */
+    public static boolean areNumbersVisible() {
+    	return Settings.numsVisible;
+    }
+    
+    /**
+     * Sets whether measure numbers on the staff should be visible.
+     * 
+     * @param visibility The visibility flag setting to use.
+     */
+    public static void setNumbersVisibility(boolean visibility) {
+    	Settings.numsVisible = visibility;
     }
 
 }

--- a/src/gui/Values.java
+++ b/src/gui/Values.java
@@ -1,7 +1,10 @@
 package gui;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
+import backend.songs.NoteInfo;
 import backend.songs.Pitch;
 import backend.songs.TimeSignature;
 import gui.components.buttons.SMPInstrumentButtonGroup;
@@ -141,24 +144,17 @@ public class Values {
     public static final int DRUMCHANNEL = 10;
 
     /** Array of notes that we can see on the staff. */
-    public static final Pitch[] STAFF_NOTES = {
-            Pitch.valueOf(36), Pitch.valueOf(38), Pitch.valueOf(40),
-            Pitch.valueOf(41), Pitch.valueOf(43), Pitch.valueOf(45),
-            Pitch.valueOf(47), Pitch.valueOf(48), Pitch.valueOf(50),
-            Pitch.valueOf(52), Pitch.valueOf(53), Pitch.valueOf(55),
-            Pitch.valueOf(57), Pitch.valueOf(59), Pitch.valueOf(60),
-            Pitch.valueOf(62), Pitch.valueOf(64), Pitch.valueOf(65),
-            Pitch.valueOf(67), Pitch.valueOf(69), Pitch.valueOf(71),
-            Pitch.valueOf(72), Pitch.valueOf(74), Pitch.valueOf(76),
-            Pitch.valueOf(77), Pitch.valueOf(79), Pitch.valueOf(81),
-            Pitch.valueOf(83), Pitch.valueOf(84) };
-    
-    public static final String[] STAFF_NOTE_NAMES = {
-            "C2", "D2", "E2", "F2", "G2", "A2", "B2",
-            "C3", "D3", "E3", "F3", "G3", "A3", "B3",
-            "C4", "D4", "E4", "F4", "G4", "A4", "B4",
-            "C5", "D5", "E5", "F5", "G5", "A5", "B5",
-            "C6"
+    private static final NoteInfo[] STAFF_NOTES = {
+    		NoteInfo.of(36, "C2"), NoteInfo.of(38, "D2"), NoteInfo.of(40, "E2"),
+        	NoteInfo.of(41, "F2"), NoteInfo.of(43, "G2"), NoteInfo.of(45, "A2"),
+        	NoteInfo.of(47, "B2"), NoteInfo.of(48, "C3"), NoteInfo.of(50, "D3"),
+        	NoteInfo.of(52, "E3"), NoteInfo.of(53, "F3"), NoteInfo.of(55, "G3"),
+        	NoteInfo.of(57, "A3"), NoteInfo.of(59, "B3"), NoteInfo.of(60, "C4"),
+        	NoteInfo.of(62, "D4"), NoteInfo.of(64, "E4"), NoteInfo.of(65, "F4"),
+        	NoteInfo.of(67, "G4"), NoteInfo.of(69, "A4"), NoteInfo.of(71, "B4"),
+        	NoteInfo.of(72, "C5"), NoteInfo.of(74, "D5"), NoteInfo.of(76, "E5"),
+        	NoteInfo.of(77, "F5"), NoteInfo.of(79, "G5"), NoteInfo.of(81, "A5"),
+        	NoteInfo.of(83, "B5"), NoteInfo.of(84, "C6")
     };
     
     /**
@@ -237,7 +233,7 @@ public class Values {
     
     // Synchronize animations for all buttons in this group
     public static final SMPInstrumentButtonGroup INSTRUMENT_BTNS_GROUP = new SMPInstrumentButtonGroup();
-    
+        
     /**
      * Gets the current default volume value.
      * 
@@ -254,6 +250,39 @@ public class Values {
      */
     public static void setDefaultVolume(int vol) {
     	Values.DEFAULT_VELOCITY = vol;
+    }
+    
+    /**
+     * Get a {@link Pitch} note given its vertical staff bar position,
+     * optionally altered by an accidental offset. 
+     * 
+     * @param verticalPosition The vertical staff bar position of the base note.
+     * @param accidentalOffset Amount of offset to add due to accidentals.
+     * @return The {@link Pitch} representing the obtained note.
+     */
+    public static Pitch getNotePitch(int verticalPosition, int accidentalOffset) {
+    	return Pitch.valueOf(Values.STAFF_NOTES[verticalPosition].getValue() + accidentalOffset);
+    }
+    
+    /**
+     * Get the name associated to the note
+     * in the vertical staff bar position.
+     * 
+     * @param verticalPosition The vertical staff bar position of the note.
+     * @return The name of the note.
+     */
+    public static String getNoteName(int verticalPosition) {
+    	return Values.STAFF_NOTES[verticalPosition].getName();
+    }
+    
+    /**
+     * Get the staff notes as a {@link List}.
+     * 
+     * @return The staff notes described as a
+     *         {@link List} of {@link NodeInfo} objects.
+     */
+    public static List<NoteInfo> getNotes() {
+    	return Arrays.asList(Values.STAFF_NOTES);
     }
     
 }

--- a/src/gui/Values.java
+++ b/src/gui/Values.java
@@ -54,7 +54,7 @@ public class Values {
      * The default volume that we will be playing notes at. This can be changed
      * over the course of the use of this program.
      */
-    public static int DEFAULT_VELOCITY = 96;
+    private static int DEFAULT_VELOCITY = 96;
 
     /**
      * The number of distinct steps of notes in a note line on the staff. This
@@ -237,5 +237,23 @@ public class Values {
     
     // Synchronize animations for all buttons in this group
     public static final SMPInstrumentButtonGroup INSTRUMENT_BTNS_GROUP = new SMPInstrumentButtonGroup();
+    
+    /**
+     * Gets the current default volume value.
+     * 
+     * @return An {@code int} representing the current default volume.
+     */
+    public static int getDefaultVolume() {
+    	return Values.DEFAULT_VELOCITY;
+    }
+    
+    /**
+     * Sets the current default volume value.
+     * 
+     * @param vol The volume amount to set as default.
+     */
+    public static void setDefaultVolume(int vol) {
+    	Values.DEFAULT_VELOCITY = vol;
+    }
     
 }

--- a/src/gui/clipboard/StaffClipboardAPI.java
+++ b/src/gui/clipboard/StaffClipboardAPI.java
@@ -141,7 +141,7 @@ public class StaffClipboardAPI {
             Note theStaffNote = new Note(note);
 
             if (lineDest.getNotes().isEmpty()) {
-                lineDest.setVolume(Values.DEFAULT_VELOCITY);
+                lineDest.setVolume(Values.getDefaultVolume());
                 
                 if (line - StateMachine.getMeasureLineNum() < Values.NOTELINES_IN_THE_WINDOW) {
                     StaffVolumeEventHandler sveh = theStaff.getDisplayManager()
@@ -149,7 +149,7 @@ public class StaffClipboardAPI {
                     sveh.updateVolume();
                 }
 
-                commandManager.execute(new AddVolumeCommand(lineDest, Values.DEFAULT_VELOCITY));
+                commandManager.execute(new AddVolumeCommand(lineDest, Values.getDefaultVolume()));
             }
 
             if (!lineDest.getNotes().contains(theStaffNote)) {

--- a/src/gui/components/staff/StaffDisplayManager.java
+++ b/src/gui/components/staff/StaffDisplayManager.java
@@ -394,7 +394,7 @@ public class StaffDisplayManager {
             Text currText = measureNums.get(i);
             
             currImage.setVisible(Settings.areBarsVisible());
-            currText.setVisible(Settings.numsVisible);
+            currText.setVisible(Settings.areNumbersVisible());
 
             int currentIndex = currLine + i;
             int currentBarIndex = currentIndex / barLength;

--- a/src/gui/components/staff/StaffDisplayManager.java
+++ b/src/gui/components/staff/StaffDisplayManager.java
@@ -393,7 +393,7 @@ public class StaffDisplayManager {
             ImageView currImage = measureLines.get(i);
             Text currText = measureNums.get(i);
             
-            currImage.setVisible(Settings.barsVisible);
+            currImage.setVisible(Settings.areBarsVisible());
             currText.setVisible(Settings.numsVisible);
 
             int currentIndex = currLine + i;

--- a/src/gui/components/staff/StaffMouseEventHandler.java
+++ b/src/gui/components/staff/StaffMouseEventHandler.java
@@ -13,7 +13,6 @@ import backend.songs.MuteModifier;
 import backend.songs.Note;
 import backend.songs.NoteLine;
 import gui.SMPInstrument;
-import gui.Settings;
 import gui.Staff;
 import gui.StateMachine;
 import gui.Values;
@@ -187,7 +186,7 @@ public class StaffMouseEventHandler implements EventHandler<MouseEvent> {
         boolean muteA = StateMachine.isMuteAPressed();
         
         if (vel <= 0 || vel >= 128)
-            vel = Values.DEFAULT_VELOCITY;
+            vel = Values.getDefaultVolume();
 
         log.debug("Index: {}", theInd);
         log.debug("Position: {}", position);
@@ -207,8 +206,8 @@ public class StaffMouseEventHandler implements EventHandler<MouseEvent> {
                 line + StateMachine.getMeasureLineNum());
 
         if (temp.getNotes().isEmpty()) {
-            temp.setVolume(Values.DEFAULT_VELOCITY);
-            commandManager.execute(new AddVolumeCommand(temp, Values.DEFAULT_VELOCITY));
+            temp.setVolume(Values.getDefaultVolume());
+            commandManager.execute(new AddVolumeCommand(temp, Values.getDefaultVolume()));
         }
 
         if (!temp.getNotes().contains(theStaffNote)) {
@@ -262,7 +261,7 @@ public class StaffMouseEventHandler implements EventHandler<MouseEvent> {
                     .getVolHandler(line);
             sveh.setVolumeVisible(false);
             commandManager.execute(new RemoveVolumeCommand(temp, temp.getVolume()));
-            temp.setVolume(Values.DEFAULT_VELOCITY);
+            temp.setVolume(Values.getDefaultVolume());
         }
         theStaff.redraw();
     }

--- a/src/gui/loaders/SoundfontLoader.java
+++ b/src/gui/loaders/SoundfontLoader.java
@@ -13,7 +13,6 @@ import javax.sound.midi.Soundbank;
 import backend.sound.SMPSynthesizer;
 import backend.sound.SoundPlayer;
 import gui.SMPInstrument;
-import gui.Settings;
 import gui.Utilities;
 import gui.Values;
 import gui.resources.FetchStrategy;


### PR DESCRIPTION
This PR redescribes the way mutable static values and complex structures are used throughout the program.

* Static members that are not declared `final` because they mutate, are given their own static getters and setters, reducing visiblity of the raw member, in accordance to SonarLint rules.
* The arrays of staff notes and names have been fused into an array of objects `NoteInfo`, which is just a pair of note value and name. Methods indexing to this structure receive a `List` wrapper, and two additional methods are introduced:
    - A method to compute a `Pitch` of the vertical staff bar position, with an accidental offset.
    - A method to get the name of the note at the vertical staff bar position.

With these changes in place, a few SonarLint warnings are resolved.