### PR TITLE
Solve more SonarLint warnings

### DIFF
--- a/src/backend/editing/CommandManager.java
+++ b/src/backend/editing/CommandManager.java
@@ -33,7 +33,7 @@ public class CommandManager {
 
     public void undo() {
         /* make sure any current action is recorded before undoing */
-        record();
+        doRecord();
         
         if (undoStack.isEmpty())
             return;
@@ -80,7 +80,7 @@ public class CommandManager {
     /**
      * record the commands given to execute()
      */
-    public void record() {      
+    public void doRecord() {
         if (nextCommands == null)
             return;
         if (undoStack.size() >= Values.MAX_UNDO_REDO_SIZE)

--- a/src/backend/saving/ArrangementDecoders.java
+++ b/src/backend/saving/ArrangementDecoders.java
@@ -1,0 +1,32 @@
+package backend.saving;
+
+import java.util.Optional;
+
+import backend.saving.ams.AMSArrangementDecoder;
+import backend.saving.mpc.MPCArrangementDecoder;
+import backend.saving.smp.SMPArrangementDecoder;
+import backend.songs.Arrangement;
+
+public enum ArrangementDecoders {
+
+	MPC(new MPCArrangementDecoder()),
+	AMS(new AMSArrangementDecoder()),
+	SMP(new SMPArrangementDecoder());
+	
+	private Decoder<Arrangement> decoder;
+	
+	private ArrangementDecoders(Decoder<Arrangement> decoder) {
+		this.decoder = decoder;
+	}
+	
+	public Decoder<Arrangement> getDecoder() {
+		return decoder;
+	}
+	
+	public static Decoder<Optional<Arrangement>> getAllTryable() {
+		// On wrong inputs, the SMP decoder tends to return empty songs
+		// instead of throwing exceptions. This is why we try it last.
+		return CheckedDecoder.of(MPC.getDecoder(), SMP.getDecoder());
+	}
+	
+}

--- a/src/backend/saving/CheckedDecoder.java
+++ b/src/backend/saving/CheckedDecoder.java
@@ -1,0 +1,44 @@
+package backend.saving;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Optional;
+
+/**
+ * Parsers whose implementation does not throw {@link ParseException}.
+ */
+public interface CheckedDecoder<T> extends Decoder<T> {
+
+	@Override
+    T decode(File in) throws IOException;
+	
+	/**
+     * Try several parsers in sequence until one succeeds.
+     * 
+     * @param <T> the generic return type common to all parsers
+     * @param parsers the parsers to try in sequence
+     * @return Either the value returned by the first parser that succeeds, or empty
+     */
+	@SafeVarargs
+	static <T> CheckedDecoder<Optional<T>> of(Decoder<? extends T>... parsers) {
+		return new CheckedDecoder<>() {
+            
+            @Override
+            public Optional<T> decode(File in) throws IOException {
+                for (Decoder<? extends T> p : parsers) {
+                    try {
+                        T result = p.decode(in);
+                        return Optional.of(result);
+                    } catch (ParseException e) {
+                        // Continue.
+                    }
+                }
+                
+                return Optional.empty();
+            }
+            
+        };
+	}
+	
+}

--- a/src/backend/saving/Decoder.java
+++ b/src/backend/saving/Decoder.java
@@ -3,70 +3,9 @@ package backend.saving;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.Optional;
-
-import backend.saving.ams.AMSArrangementDecoder;
-import backend.saving.ams.AMSDecoder;
-import backend.saving.mpc.MPCArrangementDecoder;
-import backend.saving.mpc.MPCDecoder;
-import backend.saving.smp.SMPArrangementDecoder;
-import backend.saving.smp.SMPDecoder;
-import backend.songs.Arrangement;
-import backend.songs.Song;
 
 public interface Decoder<T> {
     
-    public T decode(File in) throws ParseException, IOException;
+    T decode(File in) throws ParseException, IOException;
     
-    /**
-     * Try several parsers in sequence until one succeeds.
-     * @param <T> the generic return type common to all parsers
-     * @param parsers the parsers to try in sequence
-     * @return Either the value returned by the first parser that succeeds, or empty
-     */
-    @SafeVarargs
-    public static <T> CheckedDecoder<Optional<T>> trySequence(Decoder<? extends T> ... parsers) {
-        return new CheckedDecoder<>() {
-            
-            @Override public Optional<T> decode(File in) throws IOException {
-                for (Decoder<? extends T> p : parsers) {
-                    try {
-                        T result = p.decode(in);
-                        return Optional.of(result);
-                    } catch (ParseException e) {
-                        // Continue.
-                    }
-                }
-                
-                return Optional.empty();
-            }
-            
-        };
-    }
-
-    public static final Decoder<Song> MPC_SEQUENCE_DECODER = new MPCDecoder();
-    public static final Decoder<Song> AMS_SEQUENCE_DECODER = new AMSDecoder();
-    public static final Decoder<Song> SMP_SEQUENCE_DECODER = new SMPDecoder();
-    
-    public static final Decoder<Arrangement> MPC_ARRANGEMENT_DECODER = new MPCArrangementDecoder();
-    public static final Decoder<Arrangement> AMS_ARRANGEMENT_DECODER = new AMSArrangementDecoder();
-    public static final Decoder<Arrangement> SMP_ARRANGEMENT_DECODER = new SMPArrangementDecoder();
-    
-    // TODO Add AMS parsers when they are implemented
-    // On wrong inputs, the SMP decoder tends to return empty songs instead of throwing exceptions
-    // ... This is why we try it last
-    public static final CheckedDecoder<Optional<Song>> SEQUENCE_DECODER = Decoder.trySequence(MPC_SEQUENCE_DECODER, SMP_SEQUENCE_DECODER);
-    public static final CheckedDecoder<Optional<Arrangement>> ARRANGEMENT_DECODER = Decoder.trySequence(MPC_ARRANGEMENT_DECODER, SMP_ARRANGEMENT_DECODER);
-    
-    /**
-     * Parsers whose implementation does not throw {@link ParseException}.
-     * @param <T>
-     */
-    public static interface CheckedDecoder<T> extends Decoder<T> {
-        
-        @Override
-        public T decode(File in) throws IOException;
-        
-    }
-
 }

--- a/src/backend/saving/SequenceDecoders.java
+++ b/src/backend/saving/SequenceDecoders.java
@@ -1,0 +1,32 @@
+package backend.saving;
+
+import java.util.Optional;
+
+import backend.saving.ams.AMSDecoder;
+import backend.saving.mpc.MPCDecoder;
+import backend.saving.smp.SMPDecoder;
+import backend.songs.Song;
+
+public enum SequenceDecoders {
+
+	MPC(new MPCDecoder()),
+	AMS(new AMSDecoder()),
+	SMP(new SMPDecoder());
+	
+	private Decoder<Song> decoder;
+	
+	private SequenceDecoders(Decoder<Song> decoder) {
+		this.decoder = decoder;
+	}
+	
+	public Decoder<Song> getDecoder() {
+		return decoder;
+	}
+	
+	public static CheckedDecoder<Optional<Song>> getAllTryable() {
+		// On wrong inputs, the SMP decoder tends to return empty songs
+		// instead of throwing exceptions. This is why we try it last.
+		return CheckedDecoder.of(MPC.getDecoder(), SMP.getDecoder());
+	}
+	
+}

--- a/src/backend/saving/ams/AMSDecoder.java
+++ b/src/backend/saving/ams/AMSDecoder.java
@@ -16,7 +16,7 @@ import backend.sound.SMPSoundfont;
 public class AMSDecoder implements Decoder<Song> {
 
     public Song decode(File file) {
-        // TODO: Fix this.
+    	// TODO: Implement reading for AMS songs.
         return null;
     }
 
@@ -48,7 +48,7 @@ public class AMSDecoder implements Decoder<Song> {
      * otherwise.
      */
     private boolean isValid(String in) {
-        // TODO Auto-generated method stub
+        // This is currently unimplemented; any file is thus invalid.
         return false;
     }
 

--- a/src/backend/saving/mpc/MPCArrangementDecoder.java
+++ b/src/backend/saving/mpc/MPCArrangementDecoder.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.text.ParseException;
 
 import backend.saving.Decoder;
+import backend.saving.SequenceDecoders;
 import backend.songs.Arrangement;
 import backend.songs.Song;
 
@@ -67,7 +68,7 @@ public class MPCArrangementDecoder implements Decoder<Arrangement> {
         for (String s : str.split("\n")) {
             String st = inputFile.getParent() + File.separatorChar + s + "]MarioPaint.txt";
             File f = new File(st);
-            Song seq = Decoder.MPC_SEQUENCE_DECODER.decode(f);
+            Song seq = SequenceDecoders.MPC.getDecoder().decode(f);
             theArr.getSequences().add(seq);
         }
         return theArr;

--- a/src/backend/saving/smp/SMPArrangementDecoder.java
+++ b/src/backend/saving/smp/SMPArrangementDecoder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Scanner;
 
 import backend.saving.Decoder;
+import backend.saving.SequenceDecoders;
 import backend.songs.Arrangement;
 import backend.songs.Song;
 
@@ -53,7 +54,7 @@ public class SMPArrangementDecoder implements Decoder<Arrangement> {
 		List<Song> seqs = new ArrayList<>();
         for (String s : read) {
             f = new File(basePath + s + ".txt");
-			seqs.add(Decoder.SMP_SEQUENCE_DECODER.decode(f));
+			seqs.add(SequenceDecoders.SMP.getDecoder().decode(f));
         }
 		loaded.getSequences().addAll(seqs);
         return loaded;

--- a/src/backend/songs/Note.java
+++ b/src/backend/songs/Note.java
@@ -1,5 +1,7 @@
 package backend.songs;
 
+import java.util.Objects;
+
 import gui.SMPInstrument;
 import gui.Values;
 
@@ -141,6 +143,11 @@ public class Note {
                 && other.instrument == instrument
                 && other.accidental == accidental
                 && other.muteModifier == muteModifier;
+    }
+    
+    @Override
+    public int hashCode() {
+    	return Objects.hash(verticalPosition, instrument, accidental, muteModifier);
     }
 
 }

--- a/src/backend/songs/TimeSignature.java
+++ b/src/backend/songs/TimeSignature.java
@@ -16,12 +16,11 @@ public class TimeSignature {
      */
     private final int[] divs;
 
-    /** We only use the bottom number to display time sigs as "4/4" or "12/8"
-     * for example, but it's not used for anything.
+    /**
+     * We only use the bottom number to display time sigs as "4/4" or "12/8"
+     * for example, but it's not used for anything else beyond that.
      * Kept as a legacy feature, as some song files may use this notation.
-     * @deprecated
      */
-    @Deprecated
     private final int bottom;
     
     public TimeSignature(int barLength) throws IllegalArgumentException {
@@ -65,10 +64,6 @@ public class TimeSignature {
 
     public int top() {
         return top;
-    }
-
-    public int bottom() {
-        return bottom;
     }
     
     public int[] divs() {

--- a/src/backend/songs/TimeSignature.java
+++ b/src/backend/songs/TimeSignature.java
@@ -92,6 +92,11 @@ public class TimeSignature {
         
         return true;
     }
+    
+    @Override
+    public int hashCode() {
+    	return Arrays.hashCode(divs);
+    }
 
     private static TimeSignature getExisting(String disp, int idxSlash) throws IllegalArgumentException {
     	// We support time signatures with a bottom number for some cases:

--- a/src/backend/sound/MultiSynthesizer.java
+++ b/src/backend/sound/MultiSynthesizer.java
@@ -192,9 +192,10 @@ public class MultiSynthesizer implements Synthesizer {
     /**
      * @return The Receiver of the first Synthesizer in the list of
      * Synthesizers. Not useful in the context of multiple Synthesizers.
-     * @deprecated
+     * 
+     * @deprecated This method should not be invoked.
      */
-    @Deprecated
+    @Deprecated(since = "2012-08-27")
     @Override
     public Receiver getReceiver() throws MidiUnavailableException {
         return theSynths.get(0).getReceiver();
@@ -216,10 +217,11 @@ public class MultiSynthesizer implements Synthesizer {
      * @return the Transmitter of the first Synthesizer in the list of
      * Synthesizers. Not useful in the context of multiple Synthesizers.
      * @throws MidiUnavailableException If the MultiSynthesizer is not open
-     * or if something goes wrong in getting the Trasnmitter.
-     * @deprecated
+     * or if something goes wrong in getting the Transmitter.
+     * 
+     * @deprecated This method should not be invoked.
      */
-    @Deprecated
+    @Deprecated(since = "2012-08-27")
     @Override
     public Transmitter getTransmitter() throws MidiUnavailableException {
         if (!initialized)

--- a/src/backend/sound/SoundPlayer.java
+++ b/src/backend/sound/SoundPlayer.java
@@ -162,9 +162,9 @@ public class SoundPlayer {
      * @since v1.1.2
      */
     public void loadFromAppData(String soundset) throws InvalidMidiDataException, IOException, MidiUnavailableException {
-        //TODO: check linux or mac, choose platform-specific folder
-        if(soundset.isEmpty())
+        if (soundset.isEmpty())
             return;
+        
         loadSoundfont(Values.SOUNDFONTS_FOLDER + soundset);
     }
     
@@ -189,9 +189,9 @@ public class SoundPlayer {
      * @since v1.1.2
      */
     public void loadToCache(String soundset) throws InvalidMidiDataException, IOException {
-        //TODO: check linux or mac, choose platform-specific folder
-        if(soundset.isEmpty())
+        if (soundset.isEmpty())
             return;
+        
         File f = new File(Values.SOUNDFONTS_FOLDER + soundset);
         bankCache.computeIfAbsent(soundset,
         		ss -> DataTypeUtils.rethrowAsUnchecked(MidiSystem::getSoundbank, f));

--- a/src/gui/OptionsMenu.java
+++ b/src/gui/OptionsMenu.java
@@ -286,7 +286,7 @@ public class OptionsMenu {
         cmd.redo();
         
         controller.getModifySongManager().execute(cmd);
-        controller.getModifySongManager().record();
+        controller.getModifySongManager().doRecord();
     }
     
     /** Updates the program's soundfont, bind to song if checked. */

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -27,6 +27,7 @@ import gui.clipboard.StaffClipboard;
 import gui.clipboard.StaffRubberBand;
 import gui.components.FileChooserManager;
 import gui.components.SongNameController;
+import gui.components.ModeTypeStringConverter;
 import gui.components.buttons.SMPButton;
 import gui.components.buttons.SMPHoldButton;
 import gui.components.buttons.SMPInstrumentButton;
@@ -60,8 +61,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.stage.Window;
-import javafx.util.StringConverter;
-import javafx.util.converter.BooleanStringConverter;
 import javafx.util.converter.NumberStringConverter;
 import lombok.extern.slf4j.Slf4j;
 import utilities.MathUtils;
@@ -253,15 +252,13 @@ public class SMPFXController {
         
         // We leverage the StringProperty modeText to bind the properties of the button and the mode in both direction
         // Bidirectional bindings between different types can only be done if one type is String afaik
-        Bindings.bindBidirectional(modeText.textProperty(), modeButton.selectedProperty(), new BooleanStringConverter () {
-            @Override public String toString(Boolean b) { return b ? "Arr" : "Song"; }
-            @Override public Boolean fromString(String string) { return string.equals("Arr"); }
-        });
+        Bindings.bindBidirectional(modeText.textProperty(), modeButton.selectedProperty(),
+        		new ModeTypeStringConverter<>(b -> b != null && b.booleanValue(), isArr -> isArr));
         
-        Bindings.bindBidirectional(modeText.textProperty(), StateMachine.modeProperty(), new StringConverter<SMPMode>() {
-            @Override public String toString(SMPMode mode) { return mode.equals(SMPMode.ARRANGEMENT) ? "Arr" : "Song"; }
-            @Override public SMPMode fromString(String string) { return string.equals("Arr") ? SMPMode.ARRANGEMENT : SMPMode.SONG; }
-        });
+        Bindings.bindBidirectional(modeText.textProperty(), StateMachine.modeProperty(),
+        		new ModeTypeStringConverter<>(
+        				mode -> mode.equals(SMPMode.ARRANGEMENT),
+        				isArr -> (isArr != null && isArr.booleanValue()) ? SMPMode.ARRANGEMENT : SMPMode.SONG));
         
         loopButton.selectedProperty().bindBidirectional(StateMachine.loopPressedProperty());
         muteButton.selectedProperty().bindBidirectional(StateMachine.mutePressedProperty());

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -15,7 +15,8 @@ import javax.sound.midi.MidiChannel;
 
 import backend.BackendUtils;
 import backend.editing.ModifySongManager;
-import backend.saving.Decoder;
+import backend.saving.ArrangementDecoders;
+import backend.saving.SequenceDecoders;
 import backend.songs.Accidental;
 import backend.songs.MuteModifier;
 import backend.songs.Arrangement;
@@ -917,7 +918,7 @@ public class SMPFXController {
 
     private void loadSong(File inputFile, Window owner) {
         try {
-            Song loaded = Decoder.SEQUENCE_DECODER.decode(inputFile).orElseThrow(IOException::new);
+            Song loaded = SequenceDecoders.getAllTryable().decode(inputFile).orElseThrow(IOException::new);
             staff.populateStaff(loaded);
             getModifySongManager().reset();
             getNameTextField().setText(loaded.getTitle());
@@ -949,7 +950,7 @@ public class SMPFXController {
         	if (inputFile == null)
         		return;
         	StateMachine.setCurrentDirectory(new File(inputFile.getParent()));
-        	Arrangement loaded = Decoder.SMP_ARRANGEMENT_DECODER.decode(inputFile);
+        	Arrangement loaded = ArrangementDecoders.SMP.getDecoder().decode(inputFile);
         	staff.populateStaffArrangement(loaded);
             
             arrangementList.getItems().clear();
@@ -963,7 +964,7 @@ public class SMPFXController {
         } catch (ParseException | StreamCorruptedException
         		| NullPointerException e) {
         	try {
-        		Arrangement loaded = Decoder.MPC_ARRANGEMENT_DECODER.decode(inputFile);
+        		Arrangement loaded = ArrangementDecoders.MPC.getDecoder().decode(inputFile);
         		StateMachine.setCurrentDirectory(new File(inputFile.getParent()));
         		staff.populateStaffArrangement(loaded);
         		StateMachine.setSongModified(false);

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -217,31 +217,8 @@ public class SMPFXController {
         // Set up command manager (undo and redo)
         commandManager = new ModifySongManager(() -> staff.redraw());
         
-        basePane.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
-            if (event.isControlDown())
-                StateMachine.setCtrlPressed(true);
-            if (event.isShiftDown())
-                StateMachine.setShiftPressed(true);
-            
-            if (event.isControlDown())
-                switch (event.getCode()) {
-                case Y:
-                    commandManager.redo();
-                    break;
-                case Z:
-                    commandManager.undo();
-                    break;
-                default:
-                    break;
-                }
-        });
-        
-        basePane.addEventHandler(KeyEvent.KEY_RELEASED, event -> {
-            if (!event.isControlDown())
-                StateMachine.setCtrlPressed(false);
-            if (!event.isShiftDown())
-                StateMachine.setShiftPressed(false);
-        });
+        basePane.addEventHandler(KeyEvent.KEY_PRESSED, this::manageShiftCtrlPresses);
+        basePane.addEventHandler(KeyEvent.KEY_RELEASED, this::manageShiftCtrlPresses);
         
         // Set up staff.
         StaffDisplayManager displayManager = new StaffDisplayManager(staffFrame, imagesHolder, volumeBars, commandManager, Values.NOTELINES_IN_THE_WINDOW, Values.NOTES_IN_A_LINE, Values.MAX_STACKABLE_NOTES);
@@ -456,6 +433,26 @@ public class SMPFXController {
         };
         
         Arrays.asList(btns).forEach(btn -> btn.disableProperty().bind(StateMachine.getPlaybackActiveProperty()));
+    }
+    
+    private void manageShiftCtrlPresses(KeyEvent event) {
+    	boolean ctrlPressed = event.isControlDown();
+    	
+    	StateMachine.setCtrlPressed(ctrlPressed);
+    	StateMachine.setShiftPressed(event.isShiftDown());
+    	
+    	if (ctrlPressed) {
+            switch (event.getCode()) {
+            case Y:
+                commandManager.redo();
+                break;
+            case Z:
+                commandManager.undo();
+                break;
+            default:
+                break;
+            }
+        }
     }
     
     private void onInstrumentButtonAction(SMPInstrument inst) {

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -277,16 +277,9 @@ public class SMPFXController {
         });
 
         // Set up arranger view
-        arrangerView.visibleProperty().bind(Bindings.createBooleanBinding(() -> {
-            switch (StateMachine.getMode()) {
-            case SONG:
-                return false;
-            case ARRANGEMENT:
-                return true;
-            default:
-                return false;
-            }
-        }, StateMachine.modeProperty()));
+        arrangerView.visibleProperty().bind(Bindings.createBooleanBinding(
+        		() -> StateMachine.getMode() == SMPMode.ARRANGEMENT,
+        		StateMachine.modeProperty()));
         
         arrangementList.getSelectionModel().selectedItemProperty().addListener(obs -> {
             if (StateMachine.isPlaybackActive())

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -945,7 +945,7 @@ public class SMPFXController {
         		return;
         	StateMachine.setCurrentDirectory(new File(inputFile.getParent()));
         	Arrangement loaded = Decoder.SMP_ARRANGEMENT_DECODER.decode(inputFile);
-        	staff.populateStaffArrangement(loaded, owner);
+        	staff.populateStaffArrangement(loaded);
             
             arrangementList.getItems().clear();
             for (Song seq : loaded.getSequences()) {
@@ -960,7 +960,7 @@ public class SMPFXController {
         	try {
         		Arrangement loaded = Decoder.MPC_ARRANGEMENT_DECODER.decode(inputFile);
         		StateMachine.setCurrentDirectory(new File(inputFile.getParent()));
-        		staff.populateStaffArrangement(loaded, owner);
+        		staff.populateStaffArrangement(loaded);
         		StateMachine.setSongModified(false);
         		
         	} catch (Exception e1) {

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -39,6 +39,7 @@ import gui.events.KeyboardHandlerMaker;
 import gui.loaders.ImageIndex;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
@@ -55,6 +56,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -281,33 +283,9 @@ public class SMPFXController {
         		() -> StateMachine.getMode() == SMPMode.ARRANGEMENT,
         		StateMachine.modeProperty()));
         
-        arrangementList.getSelectionModel().selectedItemProperty().addListener(obs -> {
-            if (StateMachine.isPlaybackActive())
-                return;
-            
-            int songIndex = arrangementList.getSelectionModel().getSelectedIndex();
-            if (songIndex == -1)
-            	return;
-            
-            List<Song> seq = staff.getArrangement().getSequences();
-            Window owner = arrangementList.getScene().getWindow();
-            
-            if (!confirmOperation(owner, "Load anyway?", true, false))
-            	return;
-            
-            staff.populateStaff(seq.get(songIndex));
-            seq.set(songIndex, staff.getSequence());
-        });
+        arrangementList.getSelectionModel().selectedItemProperty().addListener(this::onArrangementListSelectionChanged);
         
-        arrangementList.setCellFactory(list -> new ListCell<>() {
-        	@Override
-        	public void updateItem(Song song, boolean empty) {
-        		super.updateItem(song, empty);
-        		
-        		setGraphic(null);
-        		setText(empty || song == null ? null : song.getTitle());
-        	}
-        });
+        arrangementList.setCellFactory(this::createArrangementSongListCell);
 
         // Set up options menu
         optionsMenu = new OptionsMenu(this, staff);
@@ -331,30 +309,11 @@ public class SMPFXController {
         
         // Fix TextField focus problems.
         new SongNameController(songName, this);
-        songName.promptTextProperty().bind(Bindings.createStringBinding(() -> {
-            switch (StateMachine.getMode() ) {
-            case SONG:
-                return "Song Name:";
-            case ARRANGEMENT:
-                return "Arrangement Name:";
-            default:
-                return "";
-            }
-        }, StateMachine.modeProperty()));
+        songName.promptTextProperty().bind(Bindings.createStringBinding(
+        		this::getItemNamePromptText, StateMachine.modeProperty()));
         
         // Changing mode binds the bottom text to a different name property
-        StateMachine.modeProperty().addListener(obs -> {
-            switch (StateMachine.getMode()) {
-            case SONG:
-                songName.textProperty().unbindBidirectional(StateMachine.currentArrangementNameProperty());
-                songName.textProperty().bindBidirectional(StateMachine.currentSongNameProperty());
-                break;
-            case ARRANGEMENT:
-                songName.textProperty().unbindBidirectional(StateMachine.currentSongNameProperty());
-                songName.textProperty().bindBidirectional(StateMachine.currentArrangementNameProperty());
-                break;
-            }
-        });
+        StateMachine.modeProperty().addListener(this::onModeTypeChanged);
         
         songName.textProperty().bindBidirectional(StateMachine.currentSongNameProperty());
         
@@ -363,20 +322,7 @@ public class SMPFXController {
         
         // Set up tempo box
         tempoIndicator.textProperty().bindBidirectional(StateMachine.getTempoProperty(), new NumberStringConverter());
-
-        tempoBox.setOnMousePressed(evt -> {
-            try {
-                if (!StateMachine.isPlaybackActive() && StateMachine.getMode() == SMPMode.SONG) {
-                    Window owner = Utilities.getOwner(evt);
-                    String tempo = Dialog.showTextDialog("Tempo", owner);
-                    StateMachine.setTempo(Double.parseDouble(tempo));
-                    tempo = tempo.trim();
-                }
-            } catch (NumberFormatException e) {
-                // Do nothing.
-            }
-            evt.consume();
-        });
+        tempoBox.setOnMousePressed(this::onTempoBoxMousePressed);
         
         // Setup scrollbar
         scrollbar.maxProperty().bind(Bindings.createIntegerBinding(
@@ -401,13 +347,7 @@ public class SMPFXController {
         StateMachine.setMeasureLineNum(0);
         
         // Setup arrangement listview
-        StateMachine.getArrangementSongIndexProperty().addListener(obv -> {
-            int idx = StateMachine.getArrangementSongIndex();
-            arrangementList.getSelectionModel().select(idx);
-            if (idx != -1)
-                Platform.runLater(() -> arrangementList.scrollTo(idx));
-            StateMachine.setCurrentSongName(arrangementList.getSelectionModel().getSelectedItem().getTitle());
-        });
+        StateMachine.getArrangementSongIndexProperty().addListener(this::onArrangementSongIndexChanged);
         
         // Cleanup after a song or arrangement had finished running
         StateMachine.getPlaybackActiveProperty().addListener(obv -> {
@@ -446,6 +386,81 @@ public class SMPFXController {
                 break;
             }
         }
+    }
+    
+    private void onArrangementListSelectionChanged(Observable obs) {
+    	if (StateMachine.isPlaybackActive())
+            return;
+        
+        int songIndex = arrangementList.getSelectionModel().getSelectedIndex();
+        if (songIndex == -1)
+        	return;
+        
+        List<Song> seq = staff.getArrangement().getSequences();
+        Window owner = arrangementList.getScene().getWindow();
+        
+        if (!confirmOperation(owner, "Load anyway?", true, false))
+        	return;
+        
+        staff.populateStaff(seq.get(songIndex));
+        seq.set(songIndex, staff.getSequence());
+    }
+    
+    private ListCell<Song> createArrangementSongListCell(ListView<Song> list) {
+    	return (new ListCell<>() {
+        	@Override
+        	public void updateItem(Song song, boolean empty) {
+        		super.updateItem(song, empty);
+        		
+        		setGraphic(null);
+        		setText(empty || song == null ? null : song.getTitle());
+        	}
+        });
+    }
+    
+    private String getItemNamePromptText() {
+        switch (StateMachine.getMode()) {
+        case SONG:
+            return "Song Name:";
+        case ARRANGEMENT:
+            return "Arrangement Name:";
+        default:
+            return "";
+        }
+    }
+    
+    private void onModeTypeChanged(Observable obs) {
+    	switch (StateMachine.getMode()) {
+        case SONG:
+            songName.textProperty().unbindBidirectional(StateMachine.currentArrangementNameProperty());
+            songName.textProperty().bindBidirectional(StateMachine.currentSongNameProperty());
+            break;
+        case ARRANGEMENT:
+            songName.textProperty().unbindBidirectional(StateMachine.currentSongNameProperty());
+            songName.textProperty().bindBidirectional(StateMachine.currentArrangementNameProperty());
+            break;
+        }
+    }
+    
+    private void onTempoBoxMousePressed(MouseEvent evt) {
+    	try {
+            if (!StateMachine.isPlaybackActive() && StateMachine.getMode() == SMPMode.SONG) {
+                Window owner = Utilities.getOwner(evt);
+                String tempo = Dialog.showTextDialog("Tempo", owner);
+                StateMachine.setTempo(Double.parseDouble(tempo.trim()));
+            }
+        } catch (NumberFormatException e) {
+            // Do nothing.
+        }
+        evt.consume();
+    }
+    
+    private void onArrangementSongIndexChanged(Observable obv) {
+    	int idx = StateMachine.getArrangementSongIndex();
+        arrangementList.getSelectionModel().select(idx);
+        if (idx != -1)
+            Platform.runLater(() -> arrangementList.scrollTo(idx));
+        StateMachine.setCurrentSongName(arrangementList.getSelectionModel().getSelectedItem().getTitle());
     }
     
     private void onInstrumentButtonAction(SMPInstrument inst) {

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -117,16 +117,16 @@ public class SMPFXController {
     private SMPToggleButton clipboardButton;
     
     @FXML
-    private SMPRadioButton timesigButton_4_4;
+    private SMPRadioButton timeSigBtnFourFour;
     
     @FXML
-    private SMPRadioButton timesigButton_3_4;
+    private SMPRadioButton timeSigBtnThreeFour;
     
     @FXML
-    private SMPRadioButton timesigButton_6_8;
+    private SMPRadioButton timeSigBtnSixEight;
     
     @FXML
-    private SMPRadioButton timesigButtonCustom;
+    private SMPRadioButton timeSigBtnCustom;
     
     @FXML
     private SMPButton saveButton;
@@ -275,10 +275,10 @@ public class SMPFXController {
         
         ToggleGroup timesigToggleGroup = new ToggleGroup();
         Utilities.groupToggleBtns(timesigToggleGroup,
-        		timesigButton_4_4, timesigButton_3_4, timesigButton_6_8, timesigButtonCustom);
+        		timeSigBtnFourFour, timeSigBtnThreeFour, timeSigBtnSixEight, timeSigBtnCustom);
         
         stopButton.setSelected(true);
-        timesigButton_4_4.setSelected(true);
+        timeSigBtnFourFour.setSelected(true);
         
         String[] tooltipLines = {
             "Click (or Shift+R) to toggle region selection",
@@ -450,7 +450,7 @@ public class SMPFXController {
         
         // Disable buttons while playback is active
         Node[] btns = {
-        		timesigButton_4_4, timesigButton_3_4, timesigButton_6_8, timesigButtonCustom,
+        		timeSigBtnFourFour, timeSigBtnThreeFour, timeSigBtnSixEight, timeSigBtnCustom,
         		modeButton, saveButton, loadButton, newButton, optionsButton,
         		tempoPlusButton, tempoMinusButton, addButton, deleteButton, upButton, downButton
         };
@@ -561,19 +561,19 @@ public class SMPFXController {
         staff.stop();
     }
     
-    public void setTimesig_4_4(ActionEvent e) {
+    public void setTimeSigFourFour(ActionEvent e) {
         staff.setTimeSignature(TimeSignature.FOUR_FOUR);
     }
     
-    public void setTimesig_3_4(ActionEvent e) {
+    public void setTimeSigThreeFour(ActionEvent e) {
         staff.setTimeSignature(TimeSignature.THREE_FOUR);
     }
     
-    public void setTimesig_6_8(ActionEvent e) {
+    public void setTimeSigSixEight(ActionEvent e) {
         staff.setTimeSignature(TimeSignature.SIX_EIGHT);
     }
     
-    public void setTimesig_custom(ActionEvent e) {
+    public void setTimeSigCustom(ActionEvent e) {
         Window owner = ((Node) e.getSource()).getScene().getWindow();
         String str = Dialog.showTextDialog(null, "Enter time signature:", "4/4, 3/4, 6/8, 6+3, ...", owner, true);
         if (str.isEmpty())
@@ -584,11 +584,11 @@ public class SMPFXController {
             staff.setTimeSignature(t);
             
             if (t.equals(TimeSignature.FOUR_FOUR)) {
-                timesigButton_4_4.setSelected(true);
+                timeSigBtnFourFour.setSelected(true);
             } else if (t.equals(TimeSignature.THREE_FOUR)) {
-                timesigButton_3_4.setSelected(true);
+                timeSigBtnThreeFour.setSelected(true);
             } else if (t.equals(TimeSignature.SIX_EIGHT)) {
-                timesigButton_6_8.setSelected(true);
+                timeSigBtnSixEight.setSelected(true);
             }
             
         } catch (IllegalArgumentException ee) {

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -668,15 +668,15 @@ public class SMPFXController {
     
     @FXML
     public void moveSongUpInArrangement(ActionEvent e) {
-    	moveSongInArrangement(e, -1);
+    	moveSongInArrangement(-1);
     }
 
     @FXML
     public void moveSongDownInArrangement(ActionEvent e) {
-    	moveSongInArrangement(e, 1);
+    	moveSongInArrangement(1);
     }
     
-    private void moveSongInArrangement(ActionEvent e, int diff) {
+    private void moveSongInArrangement(int diff) {
         ObservableList<Song> l = arrangementList.getItems();
         int i = arrangementList.getSelectionModel().getSelectedIndex();
         int moveTo = MathUtils.clamp(i + diff, 0, l.size());

--- a/src/gui/SMPFXController.java
+++ b/src/gui/SMPFXController.java
@@ -77,6 +77,9 @@ import utilities.MathUtils;
 @Slf4j
 public class SMPFXController {
     
+	private static final String PROMPT_LOAD_CONFIRM = "Load anyway?";
+	private static final String PROMPT_ERROR = "Error!";
+	
     /**
      * The image that shows the selected instrument.
      */
@@ -399,7 +402,7 @@ public class SMPFXController {
         List<Song> seq = staff.getArrangement().getSequences();
         Window owner = arrangementList.getScene().getWindow();
         
-        if (!confirmOperation(owner, "Load anyway?", true, false))
+        if (!confirmOperation(owner, PROMPT_LOAD_CONFIRM, true, false))
         	return;
         
         staff.populateStaff(seq.get(songIndex));
@@ -897,7 +900,7 @@ public class SMPFXController {
     }
 
     private void loadSong(Window owner) {
-    	if (!confirmOperation(owner, "Load anyway?", true, false))
+    	if (!confirmOperation(owner, PROMPT_LOAD_CONFIRM, true, false))
             return;
     	
         try {
@@ -922,21 +925,21 @@ public class SMPFXController {
             StateMachine.setSongModified(false);
             
         } catch (FileNotFoundException e) {
-            Dialog.showDialog("Error!", "File " + inputFile + "not found!", owner);
+            Dialog.showDialog(PROMPT_ERROR, "File " + inputFile + "not found!", owner);
             log.error("File not found error in loadSong:", e);
             
         } catch (IOException e) {
-            Dialog.showDialog("Error!", "An IO exception occurred while reading file " + inputFile + "!", owner);
+            Dialog.showDialog(PROMPT_ERROR, "An IO exception occurred while reading file " + inputFile + "!", owner);
             log.error("IO error in loadSong:", e);
             
         } catch (Exception e) {
-            Dialog.showDialog("Error!", "An error occurred while reading file " + inputFile + "!", owner);
+            Dialog.showDialog(PROMPT_ERROR, "An error occurred while reading file " + inputFile + "!", owner);
             log.error("Error in loadSong:", e);
         }
     }
 
     private void loadArrangement(Window owner) {
-    	if (!confirmOperation(owner, "Load anyway?", true, true))
+    	if (!confirmOperation(owner, PROMPT_LOAD_CONFIRM, true, true))
     		return;
     	
         File inputFile = null;

--- a/src/gui/SplashScreen.java
+++ b/src/gui/SplashScreen.java
@@ -98,21 +98,21 @@ public class SplashScreen extends Preloader {
     }
 
     @Override
-    public void handleApplicationNotification(PreloaderNotification pn) {
-        if (pn instanceof ProgressNotification) {
+    public void handleApplicationNotification(PreloaderNotification notif) {
+    	if (notif instanceof ProgressNotification pn) {
             /* expect application to send us progress notifications
                with progress ranging from 0 to 1.0 */
-            double v = ((ProgressNotification) pn).getProgress();
+            double v = pn.getProgress();
             bar.setProgress(v);
             
-        } else if (pn instanceof StateChangeNotification) {
+        } else if (notif instanceof StateChangeNotification) {
             /* hide after get any state update from application */
             stage.hide();
             
-        } else if (pn instanceof ErrorNotification) {
-            if (!handleErrorNotification((ErrorNotification)pn)) {
-                stage.close();
-            }
+        } else if (notif instanceof ErrorNotification en
+        		&& !handleErrorNotification(en)) {
+        	
+            stage.close();
         }
     }
     

--- a/src/gui/Staff.java
+++ b/src/gui/Staff.java
@@ -17,7 +17,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
-import javafx.stage.Window;
 import lombok.extern.slf4j.Slf4j;
 import utilities.MathUtils;
 
@@ -323,7 +322,7 @@ public class Staff {
      * @param loaded
      *            The loaded arrangement.
      */
-    public void populateStaffArrangement(Arrangement loaded, Window owner) {
+    public void populateStaffArrangement(Arrangement loaded) {
     	Song first = loaded.getSequences().getFirst();
         populateStaff(first);
         

--- a/src/gui/Staff.java
+++ b/src/gui/Staff.java
@@ -532,12 +532,10 @@ public class Staff {
             /**
              * Bumps the highlight of the notes to the next play bar.
              *
-             * @param playBars
-             *            The list of the measure highlights.
              * @param index
              *            The current index of the measure that we're on.
              */
-            private void runUI(final int currentLoc, final int index) {
+            private void runUI(final int index) {
                 // In principle it's not necessary to send this job to the FXAT,
                 // but for some reason the program is more stable that way
                 // Leaving things as they are until someone can figure it out --rozlyn

--- a/src/gui/Staff.java
+++ b/src/gui/Staff.java
@@ -2,6 +2,7 @@ package gui;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MidiChannel;
@@ -413,7 +414,7 @@ public class Staff {
     class AnimationService extends Service<Staff> {
 
         /** Number of lines queued up to play. */
-        protected volatile int queue = 0;
+    	protected AtomicInteger queue = new AtomicInteger(0);
 
         @Override
         protected Task<Staff> createTask() {
@@ -477,18 +478,18 @@ public class Staff {
                 
                 StateMachine.setMaxLine(Math.max(endLine + Values.NOTELINES_IN_THE_WINDOW, Values.DEFAULT_LINES_PER_SONG));
 
-                queue = 0;
+                queue.set(0);
                 
                 while (songPlaying) {
                     displayManager.updatePlayBars(index);
                     
                     if (zero) {
                         resetLocation();
-                        while (queue > 0);
+                        while (queue.get() > 0);
                         zero = false;
                     }
                     
-                    queue++;
+                    queue.incrementAndGet();
                     playNextLine();
                     counter++;
                     
@@ -523,7 +524,7 @@ public class Staff {
                     setLocation(loc);
                 }
                 
-                runUI(currentLoc, index);
+                runUI(index);
                 
                 advance = index >= Values.NOTELINES_IN_THE_WINDOW - 1;
                 index = advance ? 0 : (index + 1);
@@ -543,7 +544,7 @@ public class Staff {
                     try {
                         playSoundLine(index);
                     } finally {
-                        queue--;
+                    	queue.decrementAndGet();
                     }
                 });
             }            
@@ -570,7 +571,7 @@ public class Staff {
                 List<Song> seq = getArrangement().getSequences();
                 int endLine;
 
-                queue = 0;
+                queue.set(0);
                 
                 for (int i = 0; i < seq.size(); i++) {
                     setSequence(getArrangement().getSequences().get(i));
@@ -596,7 +597,7 @@ public class Staff {
                     while (songPlaying && arrPlaying) {
                         displayManager.updatePlayBars(index);
 
-                        queue++;
+                        queue.incrementAndGet();
                         playNextLine();
                         
                         counter++;
@@ -611,7 +612,7 @@ public class Staff {
                         break;
 
                     /* Force emptying of queue before changing songs. */
-                    while (queue > 0);
+                    while (queue.get() > 0);
                 }
                 
                 StateMachine.setPlaybackActive(false);

--- a/src/gui/Staff.java
+++ b/src/gui/Staff.java
@@ -229,10 +229,7 @@ public class Staff {
             arrPlaying = false;
             animationService.cancel();
             switch (animationService.getState()) {
-            case CANCELLED:
-            case FAILED:
-            case READY:
-            case SUCCEEDED:
+            case CANCELLED, FAILED, READY, SUCCEEDED:
                 animationService.reset();
                 break;
             default:

--- a/src/gui/SuperMarioPaint.java
+++ b/src/gui/SuperMarioPaint.java
@@ -1,11 +1,13 @@
 package gui;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.function.Consumer;
@@ -116,7 +118,7 @@ public class SuperMarioPaint extends Application  {
      * This should hopefully get something up on the screen quickly. This is
      * taken from http://docs.oracle.com/javafx/2/deployment/preloaders.htm
      */
-    private void longStart() throws Exception {
+    private void longStart() throws ExecutionException, InterruptedException, IOException {
         sfLd.start();
         imgLd.start();
         

--- a/src/gui/Values.java
+++ b/src/gui/Values.java
@@ -188,20 +188,29 @@ public class Values {
             /* if it is some version of Windows */
             if (os.contains("WIN")) {
                 // it is simply the location of the "AppData" folder
-                platformFolder = System.getenv("AppData")
-                        + File.separatorChar + "Super Mario Paint";
+            	platformFolder = preparePath(
+            			System.getenv("AppData"), "Super Mario Paint");
             }
             /* Otherwise, we assume Linux or Mac */
             else if (os.contains("MAC")) {
-                platformFolder = System.getProperty("user.home")
-                        + File.separatorChar + "Library"
-                        + File.separatorChar + "Application Support"
-                        + File.separatorChar + "Super Mario Paint";
+            	platformFolder = preparePath(
+            			System.getProperty("user.home"),
+            			"Library", "Application Support", "Super Mario Paint");
             } else {
                 /* Assuming we are on Linux */
-                platformFolder = System.getProperty("user.home")
-                        + File.separatorChar + ".supermariopaint";
+            	platformFolder = preparePath(
+            			System.getProperty("user.home"), ".supermariopaint");
             }
+        }
+        
+        /**
+         * Convenience method to build a path given its parts.
+         * 
+         * @param parts One or more paths to join together.
+         * @return The joined path as a {@link String}.
+         */
+        private String preparePath(String... parts) {
+        	return String.join(File.separator, parts);
         }
         
         /**

--- a/src/gui/clipboard/StaffClipboardAPI.java
+++ b/src/gui/clipboard/StaffClipboardAPI.java
@@ -124,7 +124,7 @@ public class StaffClipboardAPI {
         }
         
         clearSelection();
-        commandManager.record();
+        commandManager.doRecord();
     }
 
     /**
@@ -195,7 +195,7 @@ public class StaffClipboardAPI {
         }
 
         theStaff.redraw();
-        commandManager.record();
+        commandManager.doRecord();
         StateMachine.setMaxLine(Math.max(theStaff.getSequence().getLength(), Values.DEFAULT_LINES_PER_SONG));
     }
 

--- a/src/gui/clipboard/StaffRubberBand.java
+++ b/src/gui/clipboard/StaffRubberBand.java
@@ -232,42 +232,6 @@ public class StaffRubberBand extends Rectangle {
     }
     
     /**
-     * @deprecated
-     * Second call this to redraw the rubber band to a new size. Alters only x 
-     * dimension.
-     *
-     * @param x x-coord to resize to
-     */
-    @Deprecated
-    public void resizeX(double x) {
-        if (x >= xOrigin) {
-            this.setTranslateX(xOrigin);
-            this.setWidth(x - xOrigin);
-        } else {
-            this.setTranslateX(x);
-            this.setWidth(xOrigin - x);
-        }
-    }
-    
-    /**
-     * @deprecated
-     * Second call this to redraw the rubber band to a new size. Alters only y 
-     * dimension.
-     *
-     * @param y y-coord to resize to
-     */
-    @Deprecated
-    public void resizeY(double y) {
-        if (y >= yOrigin) {
-            this.setTranslateY(yOrigin);
-            this.setHeight(y - yOrigin);
-        } else {
-            this.setTranslateY(y);
-            this.setHeight(yOrigin - y);
-        }
-    }
-
-    /**
      * Ends drawing the rubber band and hide it. Sets rubber band invisible.
      * Lastly call this.
      */

--- a/src/gui/clipboard/StaffRubberBand.java
+++ b/src/gui/clipboard/StaffRubberBand.java
@@ -55,8 +55,9 @@ public class StaffRubberBand extends Rectangle {
             double sameEndX = 0;
             if (getTranslateX() < xOrigin) {
                 sameEndX = getTranslateX();
-            } else {// if (rbRef.getTranslateX() == xOrigin)
-                sameEndX = getTranslateX() + getWidth();
+            } else {
+                // If the value equals "xOrigin"
+            	sameEndX = getTranslateX() + getWidth();
             }
             
             int change = newVal.intValue() - oldVal.intValue();
@@ -238,14 +239,7 @@ public class StaffRubberBand extends Rectangle {
      * @param x x-coord to resize to
      */
     @Deprecated
-    public void resizeX(double x){
-        
-//        if (x > Constants.WIDTH_DEFAULT) {
-//            x = Constants.WIDTH_DEFAULT;
-//        } else if (x < 0) {
-//            x = 0;
-//        }
-
+    public void resizeX(double x) {
         if (x >= xOrigin) {
             this.setTranslateX(xOrigin);
             this.setWidth(x - xOrigin);
@@ -263,14 +257,7 @@ public class StaffRubberBand extends Rectangle {
      * @param y y-coord to resize to
      */
     @Deprecated
-    public void resizeY(double y){
-
-//        if (y > Constants.HEIGHT_DEFAULT) {
-//            y = Constants.HEIGHT_DEFAULT;
-//        } else if (y < 0) {
-//            y = 0;
-//        }
-        
+    public void resizeY(double y) {
         if (y >= yOrigin) {
             this.setTranslateY(yOrigin);
             this.setHeight(y - yOrigin);
@@ -278,7 +265,6 @@ public class StaffRubberBand extends Rectangle {
             this.setTranslateY(y);
             this.setHeight(yOrigin - y);
         }
-        
     }
 
     /**
@@ -348,7 +334,7 @@ public class StaffRubberBand extends Rectangle {
             return 0;//-1;
         } else {
             
-            double firstPosY = positionMinBound;// + positionSpacing / 2;
+            double firstPosY = positionMinBound;
             //this is half because positions overlap one another
             double positionHalfSpacing = positionSpacing / 2;
             return Values.NOTES_IN_A_LINE - (int)((bandBottomPosY - firstPosY) / positionHalfSpacing);// - 1;
@@ -364,7 +350,7 @@ public class StaffRubberBand extends Rectangle {
             return 0;//0;
         } else {
             
-            double firstPosY = positionMinBound;// + positionSpacing / 2;
+            double firstPosY = positionMinBound;
             //this is half because positions overlap one another
             double positionHalfSpacing = positionSpacing / 2;
             return Values.NOTES_IN_A_LINE - (int)((bandTopPosY - firstPosY) / positionHalfSpacing) - 1;

--- a/src/gui/clipboard/StaffRubberBandEventHandler.java
+++ b/src/gui/clipboard/StaffRubberBandEventHandler.java
@@ -142,15 +142,6 @@ public class StaffRubberBandEventHandler implements EventHandler<MouseEvent> {
     public void initializeVolumeYMaxCoord(double y) {
         rubberBand.setVolumeYMaxCoord(y);
     }
-    
-    /**
-     * calculate this with line width
-     * @deprecated
-     */
-    @Deprecated
-    public void initializeVolumeSpacing(double x) {
-        // Intentionally left blank.
-    }
 
     /**
      * defines width between lines. REQUIRED. 

--- a/src/gui/components/ModeTypeStringConverter.java
+++ b/src/gui/components/ModeTypeStringConverter.java
@@ -1,0 +1,79 @@
+package gui.components;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javafx.util.StringConverter;
+
+/**
+ * A specialized {@link StringConverter} that converts a {@link String}
+ * denoting the mode type (either {@code Arr} for arrangements or
+ * {@code Song} for songs) into the specified object. 
+ * 
+ * @param <T> the object to convert the mode type string to/from.
+ * @author Aura Lesse Programmer 
+ */
+public class ModeTypeStringConverter<T> extends StringConverter<T> {
+
+	private static final String ARRANGEMENT = "Arr";
+	private static final String SONG = "Song";
+	
+	private Predicate<T> fnIsArrangement;
+	private Function<Boolean, T> fnGetObject;
+	
+	/**
+	 * Create a new {@link StringConverter} capable
+	 * of processing the specified object.
+	 * 
+	 * @param fnIsArrangement
+	 *        A {@link Predicate} that determines if the given object
+	 *        represents the Arrangement mode type. Used in the
+	 *        {@link toString} method.
+	 *        
+	 * @param fnGetObject
+	 *        A {@link Function} that retrieves an object depending on
+	 *        whether the evaluated string is an Arrangement or not.
+	 *        Used in the {@link fromString} method.
+	 * 
+	 * @return The newly created {@code ModeTypeStringConverter}.
+	 */
+	public ModeTypeStringConverter(
+			Predicate<T> fnIsArrangement,
+			Function<Boolean, T> fnGetObject) {
+		
+		this.fnIsArrangement = fnIsArrangement;
+		this.fnGetObject = fnGetObject;
+	}
+	
+	/**
+	 * Given an object, returns its corresponding {@link String}
+	 * representation, constrained to whether it represents
+	 * an Arrangement ({@code Arr}) or a Song ({@code Song}).
+	 * 
+	 * @param object The object to convert into the mode type string.
+	 * 
+	 * @return A {@link String} with the value "{@code Arr}" if
+	 *         the mode type is an Arrangement, or "{@code Song}"
+	 *         otherwise.
+	 */
+	@Override
+	public String toString(T object) {
+		return fnIsArrangement.test(object) ? ARRANGEMENT : SONG;
+	}
+
+	/**
+	 * Given a {@link String} representing a mode type, returns
+	 * its corresponding object.
+	 * 
+	 * @param string The mode type string to test: it can either
+	 *        be "{@code Arr}" for Arrangements or "{@code Song}"
+	 *        for Songs.
+	 * 
+	 * @return The object that corresponds to the mode type.
+	 */
+	@Override
+	public T fromString(String string) {
+		return fnGetObject.apply(string.equals(ARRANGEMENT));
+	}
+	
+}

--- a/src/gui/components/staff/NoteMatrix.java
+++ b/src/gui/components/staff/NoteMatrix.java
@@ -9,7 +9,6 @@ import backend.songs.MuteModifier;
 import backend.songs.Note;
 import backend.songs.NoteLine;
 import backend.songs.Song;
-import gui.components.staff.StaffDisplayManager.StaffNoteCoordinate;
 import gui.loaders.ImageIndex;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -128,7 +127,7 @@ class NoteMatrix {
                 int d = stackedAmounts[row];
                 if (d < disp.depth) {
                     stackedAmounts[row] = d + 1;
-                    ImageView iv = matrix.get(disp.new StaffNoteCoordinate(col, row, d).lin());
+                    ImageView iv = matrix.get(new StaffNoteCoordinate(disp, col, row, d).lin());
                     iv.setImage(imagesHolder.get(noteImageIndex(s)));
                     iv.setEffect(s.isSelected() ? StaffDisplayManager.highlightBlend : null);
                     iv.setVisible(true);
@@ -137,7 +136,7 @@ class NoteMatrix {
                 d = accStackedAmounts[row];
                 if (d < disp.depth) {
                     accStackedAmounts[row] = d + 1;
-                    ImageView iv = accMatrix.get(disp.new StaffNoteCoordinate(col, row, d).lin());
+                    ImageView iv = accMatrix.get(new StaffNoteCoordinate(disp, col, row, d).lin());
                     iv.setImage(imagesHolder.get(accImageIndex(s)));
                     iv.setVisible(true);
                 }
@@ -152,10 +151,10 @@ class NoteMatrix {
         int col = currentSilhouetteColumn;
         int row = currentSilhouette.getVerticalPosition();
         
-        silMatrix.get(disp.new StaffNoteCoordinate(col, row, -1).lin()).setVisible(false);
+        silMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin()).setVisible(false);
         
         if (currentSilhouette.getAccidental() != Accidental.NATURAL) {
-            accSilMatrix.get(disp.new StaffNoteCoordinate(col, row, -1).lin()).setVisible(false);
+            accSilMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin()).setVisible(false);
         }
         
         currentSilhouette = null;
@@ -181,12 +180,12 @@ class NoteMatrix {
         currentSilhouetteColumn = col;
         currentSilhouette = silhouette;
         
-        ImageView iv = silMatrix.get(disp.new StaffNoteCoordinate(col, row, -1).lin());
+        ImageView iv = silMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin());
         iv.setImage(imagesHolder.get(noteImageIndex(silhouette)));
         iv.setVisible(true);
         
         if (silhouette.getAccidental() != Accidental.NATURAL) {
-            ImageView acciv = accSilMatrix.get(disp.new StaffNoteCoordinate(col, row, -1).lin());
+            ImageView acciv = accSilMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin());
             acciv.setImage(imagesHolder.get(accImageIndex(silhouette)));
             acciv.setVisible(true);
         }

--- a/src/gui/components/staff/NoteMatrix.java
+++ b/src/gui/components/staff/NoteMatrix.java
@@ -151,10 +151,12 @@ class NoteMatrix {
         int col = currentSilhouetteColumn;
         int row = currentSilhouette.getVerticalPosition();
         
-        silMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin()).setVisible(false);
+        StaffNoteCoordinate snc = new StaffNoteCoordinate(disp, col, row, -1);
+        
+        silMatrix.get(snc.lin()).setVisible(false);
         
         if (currentSilhouette.getAccidental() != Accidental.NATURAL) {
-            accSilMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin()).setVisible(false);
+            accSilMatrix.get(snc.lin()).setVisible(false);
         }
         
         currentSilhouette = null;
@@ -180,12 +182,14 @@ class NoteMatrix {
         currentSilhouetteColumn = col;
         currentSilhouette = silhouette;
         
-        ImageView iv = silMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin());
+        StaffNoteCoordinate snc = new StaffNoteCoordinate(disp, col, row, -1);
+        
+        ImageView iv = silMatrix.get(snc.lin());
         iv.setImage(imagesHolder.get(noteImageIndex(silhouette)));
         iv.setVisible(true);
         
         if (silhouette.getAccidental() != Accidental.NATURAL) {
-            ImageView acciv = accSilMatrix.get(new StaffNoteCoordinate(disp, col, row, -1).lin());
+            ImageView acciv = accSilMatrix.get(snc.lin());
             acciv.setImage(imagesHolder.get(accImageIndex(silhouette)));
             acciv.setVisible(true);
         }

--- a/src/gui/components/staff/StaffDisplayManager.java
+++ b/src/gui/components/staff/StaffDisplayManager.java
@@ -226,13 +226,13 @@ public class StaffDisplayManager {
                 for (int d = 0; d < depth; d++) {
                     ImageView iv = makeNoteImageView();
                     stack.getChildren().add(iv);
-                    StaffNoteCoordinate coord = new StaffNoteCoordinate(col, row, d);
+                    StaffNoteCoordinate coord = new StaffNoteCoordinate(this, col, row, d);
                     map.put(coord, iv);
                 }
                 
                 ImageView silIv = makeNoteImageView();
                 stack.getChildren().add(silIv);
-                StaffNoteCoordinate coord = new StaffNoteCoordinate(col, row, -1);
+                StaffNoteCoordinate coord = new StaffNoteCoordinate(this, col, row, -1);
                 map.put(coord, silIv);
                 
                 vBox.getChildren().add(0, stack);
@@ -265,13 +265,13 @@ public class StaffDisplayManager {
                 for (int d = 0; d < depth; d++) {
                     ImageView iv = makeAccidentalImageView();
                     stack.getChildren().add(iv);
-                    StaffNoteCoordinate coord = new StaffNoteCoordinate(col, row, d);
+                    StaffNoteCoordinate coord = new StaffNoteCoordinate(this, col, row, d);
                     mapAcc.put(coord, iv);
                 }
                 
                 ImageView silIv = makeAccidentalImageView();
                 stack.getChildren().add(silIv);
-                StaffNoteCoordinate coord = new StaffNoteCoordinate(col, row, -1);
+                StaffNoteCoordinate coord = new StaffNoteCoordinate(this, col, row, -1);
                 mapAcc.put(coord, silIv);
                 
                 vBox.getChildren().add(0, stack);
@@ -552,38 +552,6 @@ public class StaffDisplayManager {
         
         playbars[position].setVisible(true);
         activePlaybar = position;
-    }
-    
-    /**
-     * Immutable object providing the representation for a coordinate on the staff: column, row, and depth
-     * For given maximum values of row and depth, we provide converters to and from int.
-     */
-    protected class StaffNoteCoordinate {
-        
-        public final int col;
-        public final int row;
-        public final int dep; // special value -1 refers to the layer for silhouettes (dep is irrelevant)
-        
-        public StaffNoteCoordinate(int col, int row, int dep) {
-            this.col = col;
-            this.row = row;
-            this.dep = dep;
-        }
-        
-        public StaffNoteCoordinate(StaffNoteCoordinate oth) {
-            this.col = oth.col;
-            this.row = oth.row;
-            this.dep = oth.dep;
-        }
-        
-        public boolean equals(StaffNoteCoordinate oth) {
-            return this.col == oth.col && this.row == oth.row && this.dep == oth.dep;
-        }
-        
-        public int lin() {
-            return (dep == -1) ? (height * col) + row : (depth * ((height * col) + row)) + dep;
-        }
-        
     }
 
 }

--- a/src/gui/components/staff/StaffMouseEventHandler.java
+++ b/src/gui/components/staff/StaffMouseEventHandler.java
@@ -126,7 +126,7 @@ public class StaffMouseEventHandler implements EventHandler<MouseEvent> {
     }
 
     private void mouseReleased() {
-        commandManager.record();
+        commandManager.doRecord();
     }
 
     /**

--- a/src/gui/components/staff/StaffNoteCoordinate.java
+++ b/src/gui/components/staff/StaffNoteCoordinate.java
@@ -1,0 +1,59 @@
+package gui.components.staff;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Immutable object providing the representation for a coordinate on the staff: column, row, and depth
+ * For given maximum values of row and depth, we provide converters to and from int.
+ */
+public class StaffNoteCoordinate {
+
+	private Supplier<Integer> fnGetHeight;
+	private Supplier<Integer> fnGetDepth;
+	
+	public final int col;
+    public final int row;
+    public final int dep; // special value -1 refers to the layer for silhouettes (dep is irrelevant)
+    
+    public StaffNoteCoordinate(StaffDisplayManager sdm, int col, int row, int dep) {
+    	this.fnGetHeight = () -> sdm.height;
+    	this.fnGetDepth = () -> sdm.depth;
+    	
+        this.col = col;
+        this.row = row;
+        this.dep = dep;
+    }
+    
+    public StaffNoteCoordinate(StaffNoteCoordinate oth) {
+    	this.fnGetHeight = oth.fnGetHeight;
+    	this.fnGetDepth = oth.fnGetDepth;
+    	
+        this.col = oth.col;
+        this.row = oth.row;
+        this.dep = oth.dep;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+    	if (!(obj instanceof StaffNoteCoordinate))
+    		return false;
+    	
+    	StaffNoteCoordinate other = (StaffNoteCoordinate) obj;
+    	
+    	return this.col == other.col && this.row == other.row && this.dep == other.dep;
+    }
+    
+    @Override
+    public int hashCode() {
+    	return Objects.hash(col, row, dep);
+    }
+    
+    public int lin() {
+    	int height = fnGetHeight.get();
+    	int depth = fnGetDepth.get();
+    	
+        return (dep == -1) ? (height * col) + row : (depth * ((height * col) + row)) + dep;
+    }
+	
+}

--- a/src/gui/components/staff/StaffVolumeEventHandler.java
+++ b/src/gui/components/staff/StaffVolumeEventHandler.java
@@ -37,15 +37,15 @@ public class StaffVolumeEventHandler implements EventHandler<Event> {
     private NoteLine theLine;
     
     /** The text representing the volume bar the mouse is currently hovering over. */
-    private static Text volText;
+    private Text volText;
     
     /**
      * Mouse position. Used for finding which volume bar the mouse is hovering
      * over. Note: mouseX is set only to the beginning x coordinate of the
      * volume bar's stack pane it hovers over.
      */
-    private static double mouseX;
-    private static double mouseY;
+    private double mouseX;
+    private double mouseY;
 
     private ModifySongManager commandManager;
     
@@ -60,28 +60,27 @@ public class StaffVolumeEventHandler implements EventHandler<Event> {
 
     @Override
     public void handle(Event event) {
-//        if (event.getEventType() == MouseEvent.MOUSE_PRESSED) {
-//            mousePressed((MouseEvent) event);
-//        } else if (event.getEventType() == MouseEvent.DRAG_DETECTED) {
-//            mouseDragStart();
-//        } else if (event.getEventType() == DragEvent.DRAG_DONE) {
-//            mouseDragEnd();
-//        }
-        if(event instanceof MouseEvent && 
-                ((MouseEvent)event).isPrimaryButtonDown()){
+    	if (!(event instanceof MouseEvent)) {
+    		mouseEntered();
+    		return;
+    	}
+    	
+    	MouseEvent me = (MouseEvent) event;
+    	
+        if(me.isPrimaryButtonDown()){
             mouseX = stp.getBoundsInParent().getMinX();
             mouseY = stp.getBoundsInParent().getMinY();
-            mousePressed((MouseEvent) event);
+            mousePressed(me);
             mouseEntered();
-        } else if(event.getEventType() == MouseEvent.MOUSE_ENTERED){
+        } else if(me.getEventType() == MouseEvent.MOUSE_ENTERED) {
             mouseX = stp.getBoundsInParent().getMinX();
             mouseY = stp.getBoundsInParent().getMinY();
             mouseEntered();
-        } else if(event.getEventType() == MouseEvent.MOUSE_EXITED){
+        } else if(me.getEventType() == MouseEvent.MOUSE_EXITED) {
             mouseX = -1;
             mouseY = -1;
             mouseExited();
-        } else if(event.getEventType() == MouseEvent.MOUSE_RELEASED) {
+        } else if(me.getEventType() == MouseEvent.MOUSE_RELEASED) {
             mouseReleased();
         } else {
             mouseEntered();
@@ -98,7 +97,6 @@ public class StaffVolumeEventHandler implements EventHandler<Event> {
             if(event.getY() < 0 || stp.getHeight() < event.getY())
                 return;
             double h = stp.getHeight() - event.getY();
-//            System.out.println("SGH:" + stp.getHeight() + "EGY:" + event.getY());
             setVolumeDisplay(h);
             try {
                 setVolumePercent(h / stp.getHeight());
@@ -110,7 +108,7 @@ public class StaffVolumeEventHandler implements EventHandler<Event> {
     }
     
     private void mouseReleased() {
-        commandManager.execute(new AddVolumeCommand(theLine, theLine.getVolume()));//.addVolume(theLine, theLine.getVolume());
+        commandManager.execute(new AddVolumeCommand(theLine, theLine.getVolume()));
         commandManager.record();
     }
     

--- a/src/gui/components/staff/StaffVolumeEventHandler.java
+++ b/src/gui/components/staff/StaffVolumeEventHandler.java
@@ -109,7 +109,7 @@ public class StaffVolumeEventHandler implements EventHandler<Event> {
     
     private void mouseReleased() {
         commandManager.execute(new AddVolumeCommand(theLine, theLine.getVolume()));
-        commandManager.record();
+        commandManager.doRecord();
     }
     
     /** Called whenever the mouse enters the area. */

--- a/src/resources/ui/MainWindow.fxml
+++ b/src/resources/ui/MainWindow.fxml
@@ -251,7 +251,7 @@
                                 </ImageView>
                                 
                                 <HBox alignment="CENTER" spacing="2.0">
-                                  <SMPRadioButton fx:id="timesigButton_4_4" onAction="#setTimesig_4_4" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
+                                  <SMPRadioButton fx:id="timeSigBtnFourFour" onAction="#setTimeSigFourFour" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
                                     <imagePressed>
                                       <Image url="@sprites/TIMESIG_4_4_PRESSED.png"/>
                                     </imagePressed>
@@ -260,7 +260,7 @@
                                     </imageReleased>
                                   </SMPRadioButton>
                                   
-                                  <SMPRadioButton fx:id="timesigButton_3_4" onAction="#setTimesig_3_4" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
+                                  <SMPRadioButton fx:id="timeSigBtnThreeFour" onAction="#setTimeSigThreeFour" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
                                     <imagePressed>
                                       <Image url="@sprites/TIMESIG_3_4_PRESSED.png"/>
                                     </imagePressed>
@@ -269,7 +269,7 @@
                                     </imageReleased>
                                   </SMPRadioButton>
                                   
-                                  <SMPRadioButton fx:id="timesigButton_6_8" onAction="#setTimesig_6_8" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
+                                  <SMPRadioButton fx:id="timeSigBtnSixEight" onAction="#setTimeSigSixEight" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
                                     <imagePressed>
                                       <Image url="@sprites/TIMESIG_6_8_PRESSED.png"/>
                                     </imagePressed>
@@ -278,7 +278,7 @@
                                     </imageReleased>
                                   </SMPRadioButton>
                                   
-                                  <SMPRadioButton fx:id="timesigButtonCustom" onAction="#setTimesig_custom" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
+                                  <SMPRadioButton fx:id="timeSigBtnCustom" onAction="#setTimeSigCustom" fitHeight="32.0" fitWidth="32.0" focusTraversable="false">
                                     <imagePressed>
                                       <Image url="@sprites/TIMESIG_CUSTOM_PRESSED.png"/>
                                     </imagePressed>


### PR DESCRIPTION
This PR concentrates another batch of SonarLint warnings that have been since resolved.

⚠️ It depends on #130, so please merge that one first if not done yet.

In general, the changes are as follows:

* Some methods have been created to reduce the size of `SMPFXController.initialize`.
* `AnimationService` got its `volatile int` variable `queue` changed into an `AtomicInteger`.
* `StaffNoteCoordinate` has been extracted into its own file.
* Some `@Deprecated` methods that went unused have been removed.
* Some classes that overrode `toString` also include accompanying `hashCode` methods, all based on either `Objects.hash` or `Arrays.hashCode`.
* TODOs for platform-specific code that exists, as well as commented code have also been deleted throughout the files.
* Time signature buttons have been renamed to follow convention.
* Repeated strings in `SMPFXController` have been centralized as `static final` variables.
* The description of `Decoder`s has been revamped, to use `enum`s according to type (songs or arrangements).

~~(2026.08.01) Marking this as "draft" to see if more can be included here.~~